### PR TITLE
Add CI configuration and stop using clojure 1.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+
+references:
+  base_config: &base_config
+    working_directory: ~/sayid
+    docker:
+      - image: circleci/clojure:lein-2.9.1
+
+jobs:
+  test:
+    <<: *base_config
+    steps:
+      - checkout
+      - run: lein test-all
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - test

--- a/project.clj
+++ b/project.clj
@@ -9,16 +9,16 @@
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases false}]]
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [tamarin "0.1.2"]
                  [org.clojure/tools.reader "1.3.0-alpha3"]
                  [org.clojure/tools.namespace "0.2.11"]]
   :repl-options {:nrepl-middleware [com.billpiel.sayid.nrepl-middleware/wrap-sayid]}
   :profiles {:dev {:dependencies [[nrepl "0.4.4"]]
                    :plugins [[lein-codox "0.9.4"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}}
   :codox {:project {:name "Sayid"}
           :namespaces [com.billpiel.sayid.core]}
-  :aliases {"test-all" ["with-profile" "+1.7:+1.8:+1.9" "test"]})
+  :aliases {"test-all" ["with-profile" "+1.8:+1.9:+1.10" "test"]})


### PR DESCRIPTION
I could not see any CI configuration so I just added CircleCI, and removed clojure 1.7 which for me was failing locally anyway with both JDK 8 and JDK 12.

It seems to work as you can see https://circleci.com/gh/AndreaCrotti/sayid/6
you just have to enable it though in CircleCI.