### PR TITLE
Return the map defined by `sayid-clj-mode-keys`

### DIFF
--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -912,7 +912,8 @@ Place expression in kill ring."
     (define-key map (kbd "s")   'sayid-show-traced)
     (define-key map (kbd "S")   'sayid-show-traced-ns)
     (define-key map (kbd "V s") 'sayid-set-view)
-    (define-key map (kbd "h")   'sayid-show-help)))
+    (define-key map (kbd "h")   'sayid-show-help)
+    map))
 
 (defun sayid-show-help ()
   "Show sayid help buffer."


### PR DESCRIPTION
`define-key` doesn't return the map it's altering, so we need to
return the map explicitly to make use of it elsewhere.