### PR TITLE
Fix links to MELPA and videos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ tools.deps config directory (often `$HOME/.clojure`).
 
 ### Emacs Integration
 
-CIDER setup also requires that the Emacs package `sayid` is installed.
-It's available on [MELPA](https://melpa.milkbox.net/#/) and MELPA
-Stable. Put this code in `init.el`, or somewhere, to load keybindings
-for clojure-mode buffers.
+CIDER setup also requires that the Emacs package `sayid` is installed. It's
+available on [MELPA](https://melpa.org/#/sayid) and [MELPA
+Stable](https://stable.melpa.org/#/sayid). Put this code in `init.el`, or
+somewhere, to load keybindings for clojure-mode buffers.
 
 ```elisp
 (eval-after-load 'clojure-mode
@@ -188,13 +188,22 @@ buffer.
 
 ### Conj 2016 Presentation
 
-I presented Sayid at the Clojure Conj conference in Austin in 2016.
+I [presented Sayid](https://www.youtube.com/watch?v=ipDhvd1NsmE) at the Clojure
+Conj conference in Austin in 2016.
+
+[![Becoming Omniscient with Sayid - Bill
+Piel](http://img.youtube.com/vi/ipDhvd1NsmE/0.jpg)](http://www.youtube.com/watch?v=ipDhvd1NsmE
+"Becoming Omniscient with Sayid - Bill Piel")
 
 ### Demo \#1 - Video
 
-A demo video I recorded after the very first alpha release. You can find
-the [contrived example](http://github.com/bpiel/contrived-example)
-project here.
+A [demo video](https://www.youtube.com/watch?v=wkduA4py-qk) I recorded after the
+very first alpha release. You can find the [contrived
+example](http://github.com/bpiel/contrived-example) project here.
+
+[![Sayid v0.0.1 - Demo
+#1](http://img.youtube.com/vi/wkduA4py-qk/0.jpg)](http://www.youtube.com/watch?v=wkduA4py-qk
+"Sayid v0.0.1 - Demo #1")
 
 ### Demo \#1 - Walkthrough
 


### PR DESCRIPTION
Just some quick fixes to links in the README.md:

- The links to the videos that were in the GitHub Pages for the `bpiel` account (original location of this project) are not in the README.md. so even though the README.md mentions the videos it doesn't link to them. For reference, you can see the Github Page of the original account at [archive.org](http://web.archive.org/web/20180802153033/http://bpiel.github.io:80/sayid/)

- The MELPA link was to the old domain, no longer working. Also added a link to MELPA Stable, which is mentioned in the README.md.

