### PR TITLE
Change `project.clj` path to already included one

### DIFF
--- a/src/com/billpiel/sayid/core.clj
+++ b/src/com/billpiel/sayid/core.clj
@@ -13,7 +13,7 @@
 
 (def version
   "The current version of sayid as a string."
-  (-> (or (io/resource "com/billpiel/sayid/project.clj")
+  (-> (or (io/resource "META-INF/leiningen/com.billpiel/sayid/project.clj")
           "project.clj")
       slurp
       read-string

--- a/src/sayid/plugin.clj
+++ b/src/sayid/plugin.clj
@@ -4,7 +4,7 @@
 
 (def version
   "The current version of sayid as a string."
-  (-> (or (io/resource "com/billpiel/sayid/project.clj")
+  (-> (or (io/resource  "META-INF/leiningen/com.billpiel/sayid/project.clj")
           "project.clj")
       slurp
       read-string


### PR DESCRIPTION
`project.clj` is not included in the current release jar at the path being used. 

`cider-nrepl` adds an extra `project.clj` to the build at the same path we're currently trying. Leiningen already includes this file at a different path though, so we can just use that one instead of including manually.

Fixes #57 