### PR TITLE
Fix sayid-version for native-comp 

### DIFF
--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -49,8 +49,8 @@
 
 (defconst sayid-version
   (eval-when-compile
-    (lm-version (or load-file-name buffer-file-name)))
-  "The current version of `clojure-mode'.")
+    (lm-version (or load-true-file-name buffer-file-name)))
+  "The current version of `sayid-mode'.")
 
 
 (defface sayid-int-face '((t :inherit default))

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -49,7 +49,7 @@
 
 (defconst sayid-version
   (eval-when-compile
-    (lm-version (or load-true-file-name buffer-file-name)))
+    (lm-version load-true-file-name))
   "The current version of `sayid-mode'.")
 
 

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -49,7 +49,8 @@
 
 (defconst sayid-version
   (eval-when-compile
-    (lm-version load-true-file-name))
+    (lm-version (if (boundp 'load-true-file-name)
+                    load-true-file-name load-file-name)))
   "The current version of `sayid-mode'.")
 
 


### PR DESCRIPTION
My `load-file-name` documentation says:

In case a .eln file is being loaded this is unreliable and ‘load-true-file-name’
should be used instead.

Indeed this seems to be always nil with native comp enabled.

https://github.com/emacs-mirror/emacs/blob/feature/native-comp/src/lread.c#L5037

`load-true-file-name` doesn't exist in non-native comp emacs so there needs to be some special logic for both unfortunately. If boundp is hacky `comp-native-compiling` might work too.