### PR TITLE
WIP: Magit integration

### DIFF
--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -26,27 +26,31 @@
 (defun sayid-magit--trace-ns-in-files (file-names)
   "Trace namespace in FILE-NAMES."
   (mapc (lambda (file-name)
-            (with-current-buffer (find-file-noselect
-                                  file-name)
-              (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"
-                                             "file" (buffer-file-name))
-                                       (cider-current-connection))))
-          file-names)
+          (with-current-buffer (find-file-noselect
+                                file-name)
+            (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"
+                                           "file" (buffer-file-name))
+                                     (cider-current-connection))))
+        file-names)
   (sayid-show-traced))
 
 ;;;###autoload
 (defun sayid-magit--changed-files ()
-  "Return the absolute paths to changed files in the current .git directory."
-  (mapcar
-   (lambda (file)
-     (expand-file-name file (locate-dominating-file (buffer-file-name) ".git")))
-   (magit-changed-files (magit-read-starting-point "Sayid trace" nil "HEAD"))))
+  "Return the absolute paths to changed files which have a .clj \
+extension in the current .git directory."
+  (seq-filter
+   (apply-partially #'string-match ".clj$")
+   (mapcar
+    (lambda (file)
+      (expand-file-name file (locate-dominating-file file ".git")))
+    (magit-changed-files (magit-read-starting-point "Sayid trace" nil "HEAD")))))
 
 ;;;###autoload
 (defun sayid-magit-trace-changed-ns ()
   "Trace the changed namespaces in a git commit."
   (interactive)
-  (sayid-magit--trace-ns-in-files (sayid-magit--changed-files)))
+  (sayid-magit--trace-ns-in-files
+   (sayid-magit--changed-files)))
 
 (provide 'sayid-magit)
 

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -26,11 +26,9 @@
 (defun sayid-magit--trace-ns-in-files (file-names)
   "Trace namespace in FILE-NAMES."
   (mapc (lambda (file-name)
-          (with-current-buffer (find-file-noselect
-                                file-name)
-            (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"
-                                           "file" (buffer-file-name))
-                                     (cider-current-connection))))
+          (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"
+                                         "file" file-name)
+                                   (cider-current-connection)))
         file-names)
   (sayid-show-traced))
 

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -35,22 +35,22 @@
   (sayid-show-traced))
 
 ;;;###autoload
-(defun sayid-magit--changed-files ()
+(defun sayid-magit--changed-files (git-revision)
   "Return the absolute paths to changed files which have a .clj \
-extension in the current .git directory."
+extension in the current .git directory since GIT-REVISION."
   (seq-filter
    (apply-partially #'string-match ".clj$")
    (mapcar
     (lambda (file)
       (expand-file-name file (locate-dominating-file file ".git")))
-    (magit-changed-files (magit-read-starting-point "Sayid trace" nil "HEAD")))))
+    (magit-changed-files git-revision))))
 
 ;;;###autoload
-(defun sayid-magit-trace-changed-ns ()
-  "Trace the changed namespaces in a git commit."
-  (interactive)
+(defun sayid-magit-trace-changed-ns (git-revision)
+  "Trace the changed namespaces in a git commit since GIT-REVISION."
+  (interactive (list (magit-read-starting-point "Sayid trace" nil "HEAD")))
   (sayid-magit--trace-ns-in-files
-   (sayid-magit--changed-files)))
+   (sayid-magit--changed-files git-revision)))
 
 (provide 'sayid-magit)
 

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -36,7 +36,7 @@
 
 ;;;###autoload
 (defun sayid-magit--changed-files ()
-  "docstring"
+  "Return the absolute paths to changed files in the current .git directory."
   (mapcar
    (lambda (file)
      (expand-file-name file (locate-dominating-file (buffer-file-name) ".git")))

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -46,7 +46,7 @@
 (defun sayid-magit-trace-changed-ns ()
   "Trace the changed namespaces in a git commit."
   (interactive)
-  (sayid--trace-ns-in-files (sayid-magit--changed-files)))
+  (sayid-magit--trace-ns-in-files (sayid-magit--changed-files)))
 
 (provide 'sayid-magit)
 

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -4,7 +4,7 @@
 ;; Maintainer: Bill Piel <bill@billpiel.com>
 ;; Version: 0.0.1
 ;; URL: https://github.com/clojure-emacs/sayid
-;; Package-Requires: ((cider "0.21.0"))
+;; Package-Requires: ((cider "0.21.0") (magit "2.90.1"))
 
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -34,6 +34,7 @@
           file-names)
   (sayid-show-traced))
 
+;;;###autoload
 (defun sayid-magit--changed-files ()
   "docstring"
   (mapcar

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -1,0 +1,46 @@
+;;; sayid-magit.el --- Choose sayid tracing from magit -*- lexical-binding: t -*-
+
+;; Author: Mark Dawson
+;; Maintainer: Bill Piel <bill@billpiel.com>
+;; Version: 0.0.1
+;; URL: https://github.com/clojure-emacs/sayid
+;; Package-Requires: ((cider "0.21.0"))
+
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+
+;;     http://www.apache.org/licenses/LICENSE-2.0
+
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;;; Commentary:
+
+;;; Code:
+
+;;;###autoload
+(defun sayid-magit--trace-ns-in-files (file-names)
+  "Trace namespace in FILE-NAMES."
+  (mapcar (lambda (file-name)
+            (with-current-buffer (find-file-noselect
+                                  (expand-file-name file-name))
+              (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"
+                                             "file" (buffer-file-name))
+                                       (cider-current-connection))))
+          file-names)
+  (sayid-show-traced))
+
+;;;###autoload
+(defun sayid-magit-trace-changed-ns ()
+  "Trace the changed namespaces in a git commit."
+  (interactive)
+  (sayid--trace-ns-in-files
+   (magit-changed-files (magit-read-starting-point "Sayid trace" nil "HEAD"))))
+
+(provide 'sayid-magit)
+
+;;; sayid-magit.el ends here

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -25,7 +25,7 @@
 ;;;###autoload
 (defun sayid-magit--trace-ns-in-files (file-names)
   "Trace namespace in FILE-NAMES."
-  (mapcar (lambda (file-name)
+  (mapc (lambda (file-name)
             (with-current-buffer (find-file-noselect
                                   file-name)
               (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"

--- a/src/el/sayid-magit.el
+++ b/src/el/sayid-magit.el
@@ -27,19 +27,25 @@
   "Trace namespace in FILE-NAMES."
   (mapcar (lambda (file-name)
             (with-current-buffer (find-file-noselect
-                                  (expand-file-name file-name))
+                                  file-name)
               (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"
                                              "file" (buffer-file-name))
                                        (cider-current-connection))))
           file-names)
   (sayid-show-traced))
 
+(defun sayid-magit--changed-files ()
+  "docstring"
+  (mapcar
+   (lambda (file)
+     (expand-file-name file (locate-dominating-file (buffer-file-name) ".git")))
+   (magit-changed-files (magit-read-starting-point "Sayid trace" nil "HEAD"))))
+
 ;;;###autoload
 (defun sayid-magit-trace-changed-ns ()
   "Trace the changed namespaces in a git commit."
   (interactive)
-  (sayid--trace-ns-in-files
-   (magit-changed-files (magit-read-starting-point "Sayid trace" nil "HEAD"))))
+  (sayid--trace-ns-in-files (sayid-magit--changed-files)))
 
 (provide 'sayid-magit)
 


### PR DESCRIPTION
Initial implementation of utility functions to integrate magit into sayid. The interactive function `sayid-magit-trace-changed-ns` will prompt the user for a commit, and trace all namespaces in files change in that commit.

This is a WIP proposed feature. Comments or thoughts are very welcome.