### PR TITLE
Fix dependency injection at jack-in time

### DIFF
--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -153,9 +153,9 @@
   "Inject the REPL dependencies of sayid at `cider-jack-in'.
 If injecting the dependencies is not preferred set `sayid-inject-dependencies-at-jack-in' to nil."
   (when (and sayid-inject-dependencies-at-jack-in
-             (boundp 'cider-jack-in-lein-plugins)
+             (boundp 'cider-jack-in-dependencies)
              (boundp 'cider-jack-in-nrepl-middlewares))
-    (add-to-list 'cider-jack-in-lein-plugins `("com.billpiel/sayid" ,sayid-injected-plugin-version))
+    (add-to-list 'cider-jack-in-dependencies `("com.billpiel/sayid" ,sayid-injected-plugin-version))
     (add-to-list 'cider-jack-in-nrepl-middlewares "com.billpiel.sayid.nrepl-middleware/wrap-sayid")))
 
 ;;;###autoload


### PR DESCRIPTION
Commit https://github.com/clojure-emacs/cider/commit/8989f40d in cider
stopped using `cider-jack-in-lein-plugins` as a method for defining
the dependencies to insert, which causes the sayid dependencies to be
missed upon jack-in.

Since we're using Cider anyways, and likely using it to define our
nREPL version, we're going to leverage the more generic
`cider-jack-in-dependencies` variable for defining the sayid
dependency.

To avoid potential version collisions, I've opted to no longer add the
sayid plugin to the `cider-jack-in-lein-plugins` variable.