### PR TITLE
Fix a few small Emacs client issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ In the `*sayid*` buffer, press `h` to pop up the help buffer.
     I -- query for this instance with modifier
     w -- show full workspace trace
     n -- jump to next call node
-    N -- apply inner trace and reply workspace
     p -- jump to prev call node
     P -- pretty print value
     C -- clear workspace trace log

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -980,7 +980,6 @@ PREFIX is the key prefix to bind the sayid commands under."
     (define-key map (kbd "I")             'sayid-query-id-w-mod)
     (define-key map (kbd "w")             'sayid-get-workspace)
     (define-key map (kbd "n")             'sayid-buffer-nav-to-next)
-    (define-key map (kbd "N")             'sayid-buf-replay-with-inner-trace)
     (define-key map (kbd "p")             'sayid-buffer-nav-to-prev)
     (define-key map (kbd "P")             'sayid-buf-pprint-at-point)
     (define-key map (kbd "v")             'sayid-toggle-view)

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -1062,7 +1062,8 @@ q -- quit window
 (define-derived-mode sayid-traced-mode fundamental-mode "SAYID-TRACED"
   "A major mode for displaying Sayid trace output."
   (read-only-mode 1)
-  (setq truncate-lines t))
+  (setq truncate-lines t)
+  (buffer-disable-undo))
 
 
 (defvar sayid-pprint-mode-map

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -240,9 +240,22 @@ BUF-NAME- is the name of the new buffer."
     (erase-buffer)
     (get-buffer buf-name-)))
 
+(defun sayid--ensure-available ()
+  "Ensure a CIDER REPL with the Sayid middleware is reachable.
+Signal a `user-error' with actionable guidance otherwise."
+  (unless (cider-connected-p)
+    (user-error "Sayid: no active nREPL connection; start a REPL with `cider-jack-in'"))
+  (unless (cider-nrepl-op-supported-p "sayid-get-workspace")
+    (user-error "Sayid: nREPL middleware not loaded; add `com.billpiel/sayid' to your plugins and restart the REPL")))
+
+(defun sayid--current-connection ()
+  "Return the current CIDER connection, ensuring Sayid is available first."
+  (sayid--ensure-available)
+  (cider-current-connection))
+
 (defun sayid-send-and-message (req &optional fail-msg)
   "Send REQ to nrepl and show results as message.  Show FAIL-MSG on failure."
-  (let* ((resp (nrepl-send-sync-request req (cider-current-connection)))
+  (let* ((resp (nrepl-send-sync-request req (sayid--current-connection)))
          (x (nrepl-dict-get resp "value")))
     (if (and fail-msg (string= x "\"\""))
         (message fail-msg)
@@ -291,7 +304,7 @@ state.  POS is the position to move cursor to."
 (defun sayid-req-get-value (req)
   "Send REQ to nrepl and return response."
   (sayid-read-if-string (nrepl-dict-get (nrepl-send-sync-request req
-                                                                 (cider-current-connection))
+                                                                 (sayid--current-connection))
                                         "value")))
 
 (defun sayid-req-insert-content (req)
@@ -557,7 +570,7 @@ Either navigate to ns view or function source."
   (interactive)
   (nrepl-send-sync-request (list "op" "sayid-trace-all-ns-in-dir"
                                  "dir" (sayid-set-trace-ns-dir))
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (sayid-show-traced))
 
 ;;;###autoload
@@ -566,7 +579,7 @@ Either navigate to ns view or function source."
   (interactive)
   (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"
                                  "file" (buffer-file-name))
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (sayid-show-traced))
 
 ;;;###autoload
@@ -578,7 +591,7 @@ Either navigate to ns view or function source."
   (nrepl-send-sync-request (list "op" "sayid-trace-ns-by-pattern"
                                  "ns-pattern" ns-pattern
                                  "ref-ns" (cider-current-ns))
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (sayid-show-traced))
 
 ;;;###autoload
@@ -586,7 +599,7 @@ Either navigate to ns view or function source."
   "Enable all traces."
   (interactive)
   (nrepl-send-sync-request (list "op" "sayid-enable-all-traces")
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (sayid-show-traced))
 
 ;;;###autoload
@@ -594,7 +607,7 @@ Either navigate to ns view or function source."
   "Disable all traces."
   (interactive)
   (nrepl-send-sync-request (list "op" "sayid-disable-all-traces")
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (sayid-show-traced))
 
 ;;;###autoload
@@ -608,7 +621,7 @@ Either navigate to ns view or function source."
                                    "fn-name" (get-text-property (point) 'name)
                                    "fn-ns" (get-text-property (point) 'ns)
                                    "type" "inner")
-                             (cider-current-connection))
+                             (sayid--current-connection))
     (sayid-show-traced ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -624,7 +637,7 @@ Either navigate to ns view or function source."
                                    "fn-name" (get-text-property (point) 'name)
                                    "fn-ns" (get-text-property (point) 'ns)
                                    "type" "outer")
-                             (cider-current-connection))
+                             (sayid--current-connection))
     (sayid-show-traced ns)
     (goto-char pos)))
 
@@ -641,10 +654,10 @@ Either navigate to ns view or function source."
         (nrepl-send-sync-request (list "op" "sayid-trace-fn-enable"
                                        "fn-name" fn-name
                                        "fn-ns" fn-ns)
-                                 (cider-current-connection))
+                                 (sayid--current-connection))
       (nrepl-send-sync-request (list "op" "sayid-trace-ns-enable"
                                      "fn-ns" fn-ns)
-                               (cider-current-connection)))
+                               (sayid--current-connection)))
     (sayid-show-traced buf-ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -662,10 +675,10 @@ Either navigate to ns view or function source."
         (nrepl-send-sync-request (list "op" "sayid-trace-fn-disable"
                                        "fn-name" (get-text-property (point) 'name)
                                        "fn-ns" (get-text-property (point) 'ns))
-                                 (cider-current-connection))
+                                 (sayid--current-connection))
       (nrepl-send-sync-request (list "op" "sayid-trace-ns-disable"
                                      "fn-ns" fn-ns)
-                               (cider-current-connection)))
+                               (sayid--current-connection)))
     (sayid-show-traced buf-ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -682,10 +695,10 @@ Either navigate to ns view or function source."
         (nrepl-send-sync-request (list "op" "sayid-trace-fn-remove"
                                        "fn-name" fn-name
                                        "fn-ns" (get-text-property (point) 'ns))
-                                 (cider-current-connection))
+                                 (sayid--current-connection))
       (nrepl-send-sync-request (list "op" "sayid-trace-ns-remove"
                                      "fn-ns" (get-text-property (point) 'ns))
-                               (cider-current-connection)))
+                               (sayid--current-connection)))
     (sayid-show-traced ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -695,7 +708,7 @@ Either navigate to ns view or function source."
   "Kill all traces."
   (interactive)
   (nrepl-send-sync-request (list "op" "sayid-remove-all-traces")
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (message "Killed all traces."))
 
 ;;;###autoload
@@ -703,7 +716,7 @@ Either navigate to ns view or function source."
   "Clear workspace log."
   (interactive)
   (nrepl-send-sync-request (list "op" "sayid-clear-log")
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (message "Cleared log."))
 
 ;;;###autoload
@@ -711,7 +724,7 @@ Either navigate to ns view or function source."
   "Reset all traces and log in workspace."
   (interactive)
   (nrepl-send-sync-request (list "op" "sayid-reset-workspace")
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (message "Removed traces. Cleared log."))
 
 (defun sayid-find-existing-file (path)
@@ -858,7 +871,7 @@ Either navigate to ns view or function source."
   (nrepl-send-sync-request (list "op" "sayid-set-view"
                                  "view-name" (concat (completing-read "view: "
                                                                       (sayid-get-views))))
-                           (cider-current-connection))
+                           (sayid--current-connection))
   (message "View set.")
   (sayid-refresh-view))
 


### PR DESCRIPTION
A batch of small, clear-cut fixes to the Emacs client:

- **Fixes #11** - sayid commands now raise a clear, actionable error when there's no CIDER REPL or the sayid middleware isn't loaded, instead of failing cryptically. All requests go through a guarded connection helper.
- **Fixes #26** - the `*sayid-traced*` buffer now disables undo like the other sayid buffers, avoiding the "undo buffer limit exceeded" error.
- **#32** - removed the dead `N` binding (it pointed to `sayid-buf-replay-with-inner-trace`, which no longer exists) and its entry in the keybinding reference. The demo walkthrough still leans on the removed replay feature and needs a separate rewrite, so this doesn't fully close #32.