### PR TITLE
Fix dependency injection at jack-in for non-Lein projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [#68](https://github.com/clojure-emacs/sayid/issues/68): Fix automatic dependency injection at `cider-jack-in` time for non-Leiningen projects.
 * Bump the minimum requirements to Clojure 1.10, nREPL 1.0, CIDER 1.0 and Emacs 28.
 * Bump the bundled `tools.reader` and `tools.namespace` dependencies.
 * Fix the broken Clojure version matrix that prevented the test suite from running on recent Leiningen.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -154,9 +154,17 @@ The injected dependencies are most likely nREPL middlewares."
   "Inject the REPL dependencies of sayid at `cider-jack-in'.
 To opt out, set `sayid-inject-dependencies-at-jack-in' to nil."
   (when (and sayid-inject-dependencies-at-jack-in
-             (boundp 'cider-jack-in-lein-plugins)
              (boundp 'cider-jack-in-nrepl-middlewares))
-    (add-to-list 'cider-jack-in-lein-plugins `("com.billpiel/sayid" ,sayid-injected-plugin-version))
+    ;; Leiningen reads `cider-jack-in-lein-plugins', but the Clojure CLI and
+    ;; other build tools only read `cider-jack-in-dependencies', so the
+    ;; dependency has to be registered in both.  `cider-add-to-alist' replaces
+    ;; any existing entry for the artifact, so this stays idempotent.
+    (when (boundp 'cider-jack-in-lein-plugins)
+      (cider-add-to-alist 'cider-jack-in-lein-plugins
+                          "com.billpiel/sayid" sayid-injected-plugin-version))
+    (when (boundp 'cider-jack-in-dependencies)
+      (cider-add-to-alist 'cider-jack-in-dependencies
+                          "com.billpiel/sayid" sayid-injected-plugin-version))
     (add-to-list 'cider-jack-in-nrepl-middlewares "com.billpiel.sayid.nrepl-middleware/wrap-sayid")))
 
 ;;;###autoload


### PR DESCRIPTION
CIDER stopped consulting `cider-jack-in-lein-plugins` for non-Leiningen projects a while back, so sayid's dependency was never injected at `cider-jack-in` time for deps.edn (and other) projects - the middleware would load but the jar wouldn't be on the classpath.

This adds sayid to `cider-jack-in-dependencies` (which covers every build tool) in addition to the existing Lein plugin entry. Adding it to both is harmless for Lein, where plugins and dependencies live on separate classpaths.

Based on @futuro's #67, broadened per @bbatsov's suggestion in that thread to add to both lists rather than swap one for the other.

Fixes #68.