### PR TITLE
Fix inner tracing of letfn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [#14](https://github.com/clojure-emacs/sayid/issues/14): Fix inner tracing of functions that use `letfn`.
 * [#68](https://github.com/clojure-emacs/sayid/issues/68): Fix automatic dependency injection at `cider-jack-in` time for non-Leiningen projects.
 * Bump the minimum requirements to Clojure 1.10, nREPL 1.0, CIDER 1.0 and Emacs 28.
 * Bump the bundled `tools.reader` and `tools.namespace` dependencies.

--- a/src/com/billpiel/sayid/inner_trace3.clj
+++ b/src/com/billpiel/sayid/inner_trace3.clj
@@ -432,6 +432,34 @@
                                   binds
                                   (path->sym path))})))
 
+(defn xpand-letfn-form
+  [binds xbody path-sym]
+  `(tr-let-ret ~path-sym
+     ~'$$
+     (letfn* ~binds
+       ~@xbody)))
+
+(defn xpand-letfn
+  [[_ binds & body :as form] src-map fn-meta path path-parent]
+  ;; `letfn*' requires its bindings to be literal fn forms, so - unlike `let' -
+  ;; we can't wrap them with tracing.  Leave the bindings untouched and trace
+  ;; only the body forms (their indices in the form start at 2).
+  (let [xmap (merge-xpansion-maps
+              (doall (map-indexed
+                      (fn [i bform]
+                        (xpand-form bform src-map fn-meta
+                                    (conj path (+ i 2)) path))
+                      body)))]
+    (layer-xpansion-maps xmap
+                         {:path-parents {path path-parent}
+                          :templates {path (mk-tree-template src-map
+                                                             (get-form-meta-somehow form)
+                                                             fn-meta
+                                                             path)}
+                          :form (xpand-letfn-form binds
+                                                  (:form xmap)
+                                                  (path->sym path))})))
+
 (defn tr-macro
   [template tree-atom mcro v]
   (let [tree @(produce-recent-tree-atom! (:inner-path template)
@@ -682,6 +710,7 @@
         (cond
           (= 'fn* head) {:form form}
           (= 'let head) (apply xpand-let args)
+          (= 'letfn* head) (apply xpand-letfn args)
           (= 'loop head) (apply xpand-loop args)
           (= 'recur head) (apply xpand-recur args)
           (= 'if head) (apply xpand-if args)

--- a/test/com/billpiel/sayid/core_test.clj
+++ b/test/com/billpiel/sayid/core_test.clj
@@ -279,3 +279,14 @@
                          :fn #{}
                          :ns #{'com.billpiel.sayid.test-ns1}}
                 :ws-slot nil}))))))
+
+(t/deftest inner-trace-letfn
+  ;; Regression test for #14: inner-tracing a function that uses `letfn` used
+  ;; to throw "Syntax error compiling fn*", because the fn bindings of the
+  ;; expanded `letfn*' form were wrapped with tracing forms.
+  (t/testing "inner-tracing a letfn-using fn"
+    (sd/ws-add-inner-trace-fn! com.billpiel.sayid.test-ns1/func-letfn)
+    (t/testing "; doesn't throw and returns the right value"
+      (t/is (= 8 (com.billpiel.sayid.test-ns1/func-letfn 3))))
+    (t/testing "; records the call"
+      (t/is (= 1 (-> (sd/ws-deref!) :children count))))))

--- a/test/com/billpiel/sayid/test_ns1.clj
+++ b/test/com/billpiel/sayid/test_ns1.clj
@@ -81,3 +81,8 @@
     (inc b)
     (+ b a)))
 
+(defn func-letfn
+  [a]
+  (letfn [(double-it [n] (* 2 n))]
+    (double-it (inc a))))
+


### PR DESCRIPTION
Inner-tracing a function that uses `letfn` threw `Syntax error compiling fn*`.

`letfn` macroexpands to `letfn*`, whose bindings must be literal `fn*` forms. The inner tracer treated `letfn*` as a generic special form and recursed into the bindings, wrapping the `fn` bindings with tracing - which `letfn*` rejects. This adds an explicit `letfn*` handler that leaves the bindings untouched and traces only the body.

Includes a regression test (`func-letfn` in test-ns1 + `inner-trace-letfn`).

Fixes #14.