### PR TITLE
Improve the g command when source can't be located

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * [#14](https://github.com/clojure-emacs/sayid/issues/14): Fix inner tracing of functions that use `letfn`.
+* [#31](https://github.com/clojure-emacs/sayid/issues/31): Keep the generated reproduction expression in the kill ring and report clearly when the source file can't be located (`sayid-gen-instance-expr`, bound to `g`).
 * [#68](https://github.com/clojure-emacs/sayid/issues/68): Fix automatic dependency injection at `cider-jack-in` time for non-Leiningen projects.
 * Bump the minimum requirements to Clojure 1.10, nREPL 1.0, CIDER 1.0 and Emacs 28.
 * Bump the bundled `tools.reader` and `tools.namespace` dependencies.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -880,14 +880,27 @@ Either navigate to ns view or function source."
 
 ;;;###autoload
 (defun sayid-gen-instance-expr ()
-  "Try to generate an expression that will reproduce traced call.
-Place expression in kill ring."
+  "Try to generate an expression that will reproduce the traced call.
+Place the expression in the kill ring and, when the function's source
+file can be found, jump to it."
   (interactive)
-  (let ((expr (sayid-req-get-value (list "op" "sayid-gen-instance-expr"
-                                         "trace-id" (get-text-property (point) 'id)))))
-    (kill-new expr)
-    (message (concat "Written to kill ring: " expr))
-    (sayid-buffer-nav-from-point)))
+  (let* ((expr (sayid-req-get-value (list "op" "sayid-gen-instance-expr"
+                                          "trace-id" (get-text-property (point) 'id))))
+         (file (get-text-property (point) 'src-file))
+         (xfile (and file (sayid-find-existing-file file))))
+    (cond
+     ((or (null expr) (string= "" expr))
+      (message "Sayid couldn't generate a reproduction expression here"))
+     ;; The reproduction expression is the main payload, so confirm it last -
+     ;; otherwise a failed source jump would clobber the kill-ring message.
+     (xfile
+      (kill-new expr)
+      (sayid-buffer-nav-from-point)
+      (message "Written to kill ring: %s" expr))
+     (t
+      (kill-new expr)
+      (message "Written to kill ring: %s (source file not found; eval the file to jump to it)"
+               expr)))))
 
 ;;;###autoload
 (defun sayid-buf-back ()


### PR DESCRIPTION
Addresses #31.

`sayid-gen-instance-expr` (the `g` key) generates a reproduction expression, puts it in the kill ring, and then tries to jump to the function's source. When the source file can't be found (e.g. it hasn't been eval'd yet), the "File not found" message from the jump clobbered the "Written to kill ring" confirmation - so it looked like the whole command failed, even though the expression was saved.

Now it confirms the kill-ring result last, guards against an empty expression, and says plainly when the source can't be located.

This is logic-reviewed and compiles/lints clean, but I couldn't exercise it against a live traced session. It does not implement the `cider-scratch` fallback bpiel floated in the issue, so I'm referencing rather than closing #31.