### PR TITLE
Align nREPL integration with current cider/cider-nrepl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Enable lexical binding in the Emacs Lisp client and tidy up its docstrings.
 * Modernize the Emacs client's nREPL usage: route all requests through CIDER's sender and drop the obsolete `cider-current-connection`.
 * Eliminate reflection warnings in the Clojure namespaces.
+* Report nREPL op failures with a CIDER-renderable error status instead of printing to the server console, and stop intercepting errors raised by other middleware.
 * [#61](https://github.com/clojure-emacs/sayid/issues/61): Remove version extraction logic.
 * Decouple the injected `sayid` plugin version from the version of the Emacs client (see `sayid-injected-plugin-version`).
 * `sayid-trace-ns-by-pattern` accepts interactive argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix the broken Clojure version matrix that prevented the test suite from running on recent Leiningen.
 * Modernize CI: run against a JDK/Clojure matrix, lint the Clojure sources with clj-kondo, and byte-compile/lint the Emacs Lisp client.
 * Enable lexical binding in the Emacs Lisp client and tidy up its docstrings.
+* Modernize the Emacs client's nREPL usage: route all requests through CIDER's sender and drop the obsolete `cider-current-connection`.
 * Eliminate reflection warnings in the Clojure namespaces.
 * [#61](https://github.com/clojure-emacs/sayid/issues/61): Remove version extraction logic.
 * Decouple the injected `sayid` plugin version from the version of the Emacs client (see `sayid-injected-plugin-version`).

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -84,6 +84,18 @@
          (println e)))
   (send-status-done msg))
 
+(defn reply:error
+  "Reply to MSG with a CIDER-renderable error response for EX and end the op.
+Mirrors the `:err'/`:ex' plus `:error'/`:done' status convention used by
+cider-nrepl, so the client surfaces the failure instead of silently getting
+no value."
+  [msg ex]
+  (t/send (:transport msg)
+          (response-for msg
+                        :status #{:error :done}
+                        :ex (str (class ex))
+                        :err (with-out-str (st/print-cause-trace ex)))))
+
 (defn find-ns-sym
   [file]
   (some->> file
@@ -575,12 +587,15 @@
 (defn wrap-sayid
   [handler]
   (fn [{:keys [op] :as msg}]
-    (try
-      ((get sayid-nrepl-ops op handler) msg)
-      (catch Throwable e
-          (println (.getMessage e))
-          (st/print-stack-trace e)
-          (reply:clj->nrepl msg (.getMessage e))))))
+    (if-let [sayid-op (get sayid-nrepl-ops op)]
+      ;; Catch `Throwable' so an error can't leave the op without a terminal
+      ;; `:done' and hang the client.  Only Sayid's own ops are guarded here -
+      ;; errors from downstream middleware belong to them, not to us.
+      (try
+        (sayid-op msg)
+        (catch Throwable e
+          (reply:error msg e)))
+      (handler msg))))
 
 
 (set-descriptor! #'wrap-sayid

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -256,14 +256,17 @@ Signal a `user-error' with actionable guidance otherwise."
   (unless (cider-nrepl-op-supported-p "sayid-get-workspace")
     (user-error "Sayid: nREPL middleware not loaded; add `com.billpiel/sayid' to your plugins and restart the REPL")))
 
-(defun sayid--current-connection ()
-  "Return the current CIDER connection, ensuring Sayid is available first."
+(defun sayid--send-sync-request (request)
+  "Send REQUEST to the Sayid nREPL middleware and return the response.
+Ensures a CIDER REPL with the middleware is available first, and routes the
+request through CIDER's sender so the active session and connection are
+resolved automatically."
   (sayid--ensure-available)
-  (cider-current-connection))
+  (cider-nrepl-send-sync-request request))
 
 (defun sayid-send-and-message (req &optional fail-msg)
   "Send REQ to nrepl and show results as message.  Show FAIL-MSG on failure."
-  (let* ((resp (nrepl-send-sync-request req (sayid--current-connection)))
+  (let* ((resp (sayid--send-sync-request req))
          (x (nrepl-dict-get resp "value")))
     (if (and fail-msg (string= x "\"\""))
         (message fail-msg)
@@ -311,8 +314,7 @@ state.  POS is the position to move cursor to."
 
 (defun sayid-req-get-value (req)
   "Send REQ to nrepl and return response."
-  (sayid-read-if-string (nrepl-dict-get (nrepl-send-sync-request req
-                                                                 (sayid--current-connection))
+  (sayid-read-if-string (nrepl-dict-get (sayid--send-sync-request req)
                                         "value")))
 
 (defun sayid-req-insert-content (req)
@@ -576,18 +578,16 @@ Either navigate to ns view or function source."
 (defun sayid-trace-all-ns-in-dir ()
   "Trace all namespaces in specified dir."
   (interactive)
-  (nrepl-send-sync-request (list "op" "sayid-trace-all-ns-in-dir"
-                                 "dir" (sayid-set-trace-ns-dir))
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-trace-all-ns-in-dir"
+                                  "dir" (sayid-set-trace-ns-dir)))
   (sayid-show-traced))
 
 ;;;###autoload
 (defun sayid-trace-ns-in-file ()
   "Trace namespace defined in current buffer."
   (interactive)
-  (nrepl-send-sync-request (list "op" "sayid-trace-ns-in-file"
-                                 "file" (buffer-file-name))
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-trace-ns-in-file"
+                                  "file" (buffer-file-name)))
   (sayid-show-traced))
 
 ;;;###autoload
@@ -596,26 +596,23 @@ Either navigate to ns view or function source."
   (interactive (list
                 (read-string "Namespace to trace (*=wildcard) "
                              (cider-current-ns))))
-  (nrepl-send-sync-request (list "op" "sayid-trace-ns-by-pattern"
-                                 "ns-pattern" ns-pattern
-                                 "ref-ns" (cider-current-ns))
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-trace-ns-by-pattern"
+                                  "ns-pattern" ns-pattern
+                                  "ref-ns" (cider-current-ns)))
   (sayid-show-traced))
 
 ;;;###autoload
 (defun sayid-trace-enable-all ()
   "Enable all traces."
   (interactive)
-  (nrepl-send-sync-request (list "op" "sayid-enable-all-traces")
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-enable-all-traces"))
   (sayid-show-traced))
 
 ;;;###autoload
 (defun sayid-trace-disable-all ()
   "Disable all traces."
   (interactive)
-  (nrepl-send-sync-request (list "op" "sayid-disable-all-traces")
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-disable-all-traces"))
   (sayid-show-traced))
 
 ;;;###autoload
@@ -625,11 +622,10 @@ Either navigate to ns view or function source."
   (let ((pos (point))
         (ns (get-text-property 1 'ns)))
     (sayid-select-traced-buf)
-    (nrepl-send-sync-request (list "op" "sayid-trace-fn"
-                                   "fn-name" (get-text-property (point) 'name)
-                                   "fn-ns" (get-text-property (point) 'ns)
-                                   "type" "inner")
-                             (sayid--current-connection))
+    (sayid--send-sync-request (list "op" "sayid-trace-fn"
+                                    "fn-name" (get-text-property (point) 'name)
+                                    "fn-ns" (get-text-property (point) 'ns)
+                                    "type" "inner"))
     (sayid-show-traced ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -641,11 +637,10 @@ Either navigate to ns view or function source."
   (let ((pos (point))
         (ns (get-text-property 1 'ns)))
     (sayid-select-traced-buf)
-    (nrepl-send-sync-request (list "op" "sayid-trace-fn"
-                                   "fn-name" (get-text-property (point) 'name)
-                                   "fn-ns" (get-text-property (point) 'ns)
-                                   "type" "outer")
-                             (sayid--current-connection))
+    (sayid--send-sync-request (list "op" "sayid-trace-fn"
+                                    "fn-name" (get-text-property (point) 'name)
+                                    "fn-ns" (get-text-property (point) 'ns)
+                                    "type" "outer"))
     (sayid-show-traced ns)
     (goto-char pos)))
 
@@ -659,13 +654,11 @@ Either navigate to ns view or function source."
         (fn-ns (get-text-property (point) 'ns)))
     (sayid-select-traced-buf)
     (if fn-name
-        (nrepl-send-sync-request (list "op" "sayid-trace-fn-enable"
-                                       "fn-name" fn-name
-                                       "fn-ns" fn-ns)
-                                 (sayid--current-connection))
-      (nrepl-send-sync-request (list "op" "sayid-trace-ns-enable"
-                                     "fn-ns" fn-ns)
-                               (sayid--current-connection)))
+        (sayid--send-sync-request (list "op" "sayid-trace-fn-enable"
+					"fn-name" fn-name
+					"fn-ns" fn-ns))
+      (sayid--send-sync-request (list "op" "sayid-trace-ns-enable"
+                                      "fn-ns" fn-ns)))
     (sayid-show-traced buf-ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -680,13 +673,11 @@ Either navigate to ns view or function source."
         (fn-ns (get-text-property (point) 'ns)))
     (sayid-select-traced-buf)
     (if fn-name
-        (nrepl-send-sync-request (list "op" "sayid-trace-fn-disable"
-                                       "fn-name" (get-text-property (point) 'name)
-                                       "fn-ns" (get-text-property (point) 'ns))
-                                 (sayid--current-connection))
-      (nrepl-send-sync-request (list "op" "sayid-trace-ns-disable"
-                                     "fn-ns" fn-ns)
-                               (sayid--current-connection)))
+        (sayid--send-sync-request (list "op" "sayid-trace-fn-disable"
+					"fn-name" (get-text-property (point) 'name)
+					"fn-ns" (get-text-property (point) 'ns)))
+      (sayid--send-sync-request (list "op" "sayid-trace-ns-disable"
+                                      "fn-ns" fn-ns)))
     (sayid-show-traced buf-ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -700,13 +691,11 @@ Either navigate to ns view or function source."
         (fn-name (get-text-property (point) 'name)))
     (sayid-select-traced-buf)
     (if fn-name
-        (nrepl-send-sync-request (list "op" "sayid-trace-fn-remove"
-                                       "fn-name" fn-name
-                                       "fn-ns" (get-text-property (point) 'ns))
-                                 (sayid--current-connection))
-      (nrepl-send-sync-request (list "op" "sayid-trace-ns-remove"
-                                     "fn-ns" (get-text-property (point) 'ns))
-                               (sayid--current-connection)))
+        (sayid--send-sync-request (list "op" "sayid-trace-fn-remove"
+					"fn-name" fn-name
+					"fn-ns" (get-text-property (point) 'ns)))
+      (sayid--send-sync-request (list "op" "sayid-trace-ns-remove"
+                                      "fn-ns" (get-text-property (point) 'ns))))
     (sayid-show-traced ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -715,24 +704,21 @@ Either navigate to ns view or function source."
 (defun sayid-kill-all-traces ()
   "Kill all traces."
   (interactive)
-  (nrepl-send-sync-request (list "op" "sayid-remove-all-traces")
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-remove-all-traces"))
   (message "Killed all traces."))
 
 ;;;###autoload
 (defun sayid-clear-log ()
   "Clear workspace log."
   (interactive)
-  (nrepl-send-sync-request (list "op" "sayid-clear-log")
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-clear-log"))
   (message "Cleared log."))
 
 ;;;###autoload
 (defun sayid-reset-workspace ()
   "Reset all traces and log in workspace."
   (interactive)
-  (nrepl-send-sync-request (list "op" "sayid-reset-workspace")
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-reset-workspace"))
   (message "Removed traces. Cleared log."))
 
 (defun sayid-find-existing-file (path)
@@ -876,10 +862,9 @@ Either navigate to ns view or function source."
 (defun sayid-set-view ()
   "Set view."
   (interactive)
-  (nrepl-send-sync-request (list "op" "sayid-set-view"
-                                 "view-name" (concat (completing-read "view: "
-                                                                      (sayid-get-views))))
-                           (sayid--current-connection))
+  (sayid--send-sync-request (list "op" "sayid-set-view"
+                                  "view-name" (concat (completing-read "view: "
+                                                                       (sayid-get-views)))))
   (message "View set.")
   (sayid-refresh-view))
 

--- a/test/com/billpiel/sayid/nrepl_middleware_test.clj
+++ b/test/com/billpiel/sayid/nrepl_middleware_test.clj
@@ -6,7 +6,16 @@
   descriptor drifting out of sync with the registered ops - the kinds of
   breakage that are easy to introduce and annoying to debug."
   (:require [clojure.test :as t]
-            [com.billpiel.sayid.nrepl-middleware :as mw]))
+            [com.billpiel.sayid.nrepl-middleware :as mw]
+            [nrepl.transport :as transport]))
+
+(defn- recording-transport
+  "An nREPL transport that records every sent message into ATOM."
+  [sent]
+  (reify transport/Transport
+    (recv [this] this)
+    (recv [this _timeout] this)
+    (send [this msg] (swap! sent conj msg) this)))
 
 (t/deftest ops-are-registered
   (t/is (seq mw/sayid-nrepl-ops)
@@ -23,6 +32,22 @@
           handler (mw/wrap-sayid (fn [msg] (reset! seen msg) :handled))]
       (t/is (= :handled (handler {:op "something-not-ours"})))
       (t/is (= {:op "something-not-ours"} @seen)))))
+
+(t/deftest failing-op-replies-with-error-status
+  (t/testing "a Sayid op that throws still terminates the op with an error status"
+    (let [sent (atom [])
+          handler (mw/wrap-sayid (fn [_] :unhandled))
+          ;; A non-existent file makes `sayid-trace-ns-in-file' throw while
+          ;; slurping, exercising the error path.
+          msg {:op "sayid-trace-ns-in-file"
+               :file "/sayid/does-not-exist.clj"
+               :transport (recording-transport sent)}]
+      (handler msg)
+      (let [statuses (->> @sent (keep :status) (apply concat) set)]
+        (t/is (contains? statuses :error)
+              "the response carries an :error status")
+        (t/is (contains? statuses :done)
+              "the op is still terminated with :done so the client doesn't hang")))))
 
 (t/deftest descriptor-matches-ops
   (let [descriptor (:nrepl.middleware/descriptor (meta #'mw/wrap-sayid))]


### PR DESCRIPTION
Brings both sides of the nREPL integration in line with how things are done in current CIDER and cider-nrepl, targeting nREPL 1.0+ and recent cider-nrepl.

**Emacs client** - requests went through the raw `nrepl-send-sync-request` while threading an explicit `cider-current-connection` (obsolete since CIDER 1.23) through all ~19 call sites. They now funnel through a small `sayid--send-sync-request` wrapper that runs the availability guard and delegates to `cider-nrepl-send-sync-request`, which resolves the session and connection itself. Byte-compiles and lints clean; I couldn't exercise it against a live REPL, so a quick smoke test of the commands would be welcome.

**nREPL middleware** - `wrap-sayid` reported a failing op by printing the stack trace to the server console and sending the message back as a normal `:value`, and it wrapped the pass-through handler so it swallowed other middleware's errors too. It now guards only Sayid's own ops and replies with the `:err`/`:ex` + `:error`/`:done` status convention cider-nrepl uses. Added a middleware test covering the error path.

Full Clojure suite + kondo green locally.