### PR TITLE
Sync help buffers and README with actual keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Modernize CI: run against a JDK/Clojure matrix, lint the Clojure sources with clj-kondo, and byte-compile/lint the Emacs Lisp client.
 * Enable lexical binding in the Emacs Lisp client and tidy up its docstrings.
 * Modernize the Emacs client's nREPL usage: route all requests through CIDER's sender and drop the obsolete `cider-current-connection`.
+* Sync the in-Emacs help buffers and the README keybinding tables with the actual keybindings (drop entries for commands that no longer exist, add the missing ones).
 * Eliminate reflection warnings in the Clojure namespaces.
 * Report nREPL op failures with a CIDER-renderable error status instead of printing to the server console, and stop intercepting errors raised by other middleware.
 * [#61](https://github.com/clojure-emacs/sayid/issues/61): Remove version extraction logic.

--- a/README.md
+++ b/README.md
@@ -153,12 +153,11 @@ Some other useful entry points:
 
 ## Using Sayid
 
-**Note: This assumes you're using the official CIDER plugin.**.
+**Note: this assumes you're using the official CIDER plugin.**
 
-Documentation is a little light at the moment. There are lists of
-keybindings. Helpfully, they are easily accessible from within emacs.
-Below are the contents of the various help buffers, as well as
-instructions on how to pop them up in time of need.
+The keybindings are grouped by buffer below. Every list is also available
+from within Emacs: press `h` in any Sayid buffer (or `C-c s h` in a Clojure
+buffer) to pop up the matching help buffer.
 
 API docs for the core namespaces are available on
 [cljdoc](https://cljdoc.org/d/com.billpiel/sayid/CURRENT).
@@ -166,14 +165,11 @@ API docs for the core namespaces are available on
 In a clojure-mode buffer, press `C-c s h` (`sayid-show-help`) to
 pop up the help buffer.
 
-    C-c s ! -- Disable traces, eval current buffer, enable traces, clear the workspace log
-    C-c s e -- Enables traces, evals the expression at point, disables traces, displays results with terse view
     C-c s f -- Queries the active workspace for entries that most closely match the context of the cursor position
-    C-c s n -- Applies an inner trace to the function at point, replays workspace, displays results
-    C-c s r -- Replays workspace, queries results by context of cursor
+    C-c s ! -- Disable traces, load the current buffer, enable traces, and clear the workspace log
     C-c s w -- Shows workspace, using the current view
     C-c s t y -- Prompts for a dir, recursively traces all ns's in that dir and subdirs
-    C-c s t p -- Prompts for a pattern (* = wildcare), and applies a trace to all *loaded* ns's whose name matches the patten
+    C-c s t p -- Prompts for a pattern (* = wildcard), and applies a trace to all *loaded* ns's whose name matches the pattern
     C-c s t b -- Trace the ns in the current buffer
     C-c s t e -- Enable the *existing* (if any) trace of the function at point
     C-c s t E -- Enable all traces
@@ -208,8 +204,10 @@ In the `*sayid*` buffer, press `h` to pop up the help buffer.
     V -- set view (see register-view)
     l, backspace -- previous buffer state
     L, S-backspace -- forward buffer state
+    c i -- inspect value at point
     g -- generate instance expression and put in kill ring
     h -- help
+    q -- quit window
 
 
 In the `*sayid-traced*` buffer, press `h` to pop up the help
@@ -222,8 +220,10 @@ buffer.
     D -- Disable ALL traces
     i -- Apply inner trace to func at point
     o -- Apply outer trace to func at point
-    r -- Remove trace from fun at point
+    r -- Remove trace from func at point
     l, backspace -- go back to trace overview (if in ns view)
+    h -- help
+    q -- quit window
 
 
 In the `*sayid-pprint*` buffer, press `h` to pop up the help
@@ -234,6 +234,9 @@ buffer.
     o -- jump out to parent node
     n -- jump to next sibling node
     p -- jump to previous sibling node
+    l -- back to trace buffer
+    h -- help
+    q -- quit window
 
 ## Demos
 

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -951,9 +951,10 @@ file can be found, jump to it."
   (interactive)
   (display-message-or-buffer "
 f -- Queries the active workspace for entries that most closely match the context of the cursor position
+! -- Disable traces, load the current buffer, enable traces, and clear the workspace log
 w -- Shows workspace, using the current view
 t y -- Prompts for a dir, recursively traces all ns's in that dir and subdirs
-t p -- Prompts for a pattern (* = wildcare), and applies a trace to all *loaded* ns's whose name matches the patten
+t p -- Prompts for a pattern (* = wildcard), and applies a trace to all *loaded* ns's whose name matches the pattern
 t b -- Trace the ns in the current buffer
 t e -- Enable the *existing* (if any) trace of the function at point
 t E -- Enable all traces
@@ -1020,8 +1021,10 @@ v -- toggle view
 V -- set view (see register-view)
 l, <backspace> -- previous buffer state
 L, <S-backspace> -- forward buffer state
+c i -- inspect value at point
 g -- generate instance expression and put in kill ring
 h -- help
+q -- quit window
 "))
 
 ;;;###autoload
@@ -1060,6 +1063,7 @@ i -- Apply inner trace to func at point
 o -- Apply outer trace to func at point
 r -- Remove trace from func at point
 l, <backspace> -- go back to trace overview (if in ns view)
+h -- help
 q -- quit window
 "))
 
@@ -1094,6 +1098,7 @@ o -- jump out to parent node
 n -- jump to next sibling node
 p -- jump to previous sibling node
 l -- back to trace buffer
+h -- help
 q -- quit window
 "))
 


### PR DESCRIPTION
The in-Emacs help buffers and the README keybinding tables had drifted from the keymaps.

- The `C-c s` table advertised `C-c s e` / `C-c s n` / `C-c s r` for eval/replay commands that don't exist (verified: no such commands in the source).
- Both the help text and the README were missing real bindings: `C-c s !`, the `*sayid*` buffer's `c i` (inspect) and `q`, and the per-buffer `h` (help).
- Fixed "wildcare"/"patten" typos and de-apologized the intro.

Every table now matches its keymap. Byte-compiles + lints clean.