### PR TITLE
Stop re-reading nREPL response values (fixes #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [#29](https://github.com/clojure-emacs/sayid/issues/29): Fix the `wrong-type-argument` error when pressing `g` (and similar commands) by no longer re-reading nREPL response values, which already arrive decoded on nREPL 1.0+.
 * [#14](https://github.com/clojure-emacs/sayid/issues/14): Fix inner tracing of functions that use `letfn`.
 * [#31](https://github.com/clojure-emacs/sayid/issues/31): Keep the generated reproduction expression in the kill ring and report clearly when the source file can't be located (`sayid-gen-instance-expr`, bound to `g`).
 * [#68](https://github.com/clojure-emacs/sayid/issues/68): Fix automatic dependency injection at `cider-jack-in` time for non-Leiningen projects.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -313,9 +313,8 @@ state.  POS is the position to move cursor to."
     (message "Sayid didn't respond. Is it loaded?")))
 
 (defun sayid-req-get-value (req)
-  "Send REQ to nrepl and return response."
-  (sayid-read-if-string (nrepl-dict-get (sayid--send-sync-request req)
-                                        "value")))
+  "Send REQ to nREPL and return the \"value\" slot of the response."
+  (nrepl-dict-get (sayid--send-sync-request req) "value"))
 
 (defun sayid-req-insert-content (req)
   "Send REQ to nrepl and populate buffer with response."
@@ -477,13 +476,6 @@ Disable traces, load buffer, enable traces, clear log."
   (set-buffer buf)
   (insert (car val))
   (sayid-put-text-props (cadr val) buf))
-
-;; I have no idea why I seem to need this
-(defun sayid-read-if-string (v)
-  "Sometimes V is a string? Seems to depend on versions of cider or something."
-  (if (stringp v)
-      (read v)
-    v))
 
 (defun sayid-list-take (n l)
   "Take N items from end of list L."


### PR DESCRIPTION
Fixes #29.

`sayid-read-if-string` called `read` on any string value coming back from the middleware - a workaround for old CIDER/nREPL versions that sometimes handed back pr-str'd values. On nREPL 1.0+ the bencode transport already decodes responses, so that extra `read` is always wrong: it turned the version string into a symbol and, worse, parsed the `g` command's reproduction expression into a list, which then blew up `kill-new` with the `wrong-type-argument` error from the issue.

I verified the wire format against a live nREPL server running the Sayid middleware:
- `sayid-version` returns the string `"0.1.0"`
- `sayid-gen-instance-expr` returns an expression string
- `sayid-get-workspace` returns an already-structured value

and confirmed end to end that `sayid-req-get-value` now hands back usable strings (so `g` / `kill-new` works) while structured responses pass through untouched.