### PR TITLE
Consolidate trace-management nREPL ops (37 → 26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Consolidate the trace-management nREPL ops into four `action`-parametrized ops (`sayid-trace-fn`, `sayid-trace-fn-at-point`, `sayid-trace-ns`, `sayid-all-traces`), trimming the middleware from 37 ops to 26. (Breaking for any third-party nREPL client; the bundled Emacs client is updated in lockstep.)
 * [#29](https://github.com/clojure-emacs/sayid/issues/29): Fix the `wrong-type-argument` error when pressing `g` (and similar commands) by no longer re-reading nREPL response values, which already arrive decoded on nREPL 1.0+.
 * [#14](https://github.com/clojure-emacs/sayid/issues/14): Fix inner tracing of functions that use `letfn`.
 * [#31](https://github.com/clojure-emacs/sayid/issues/31): Keep the generated reproduction expression in the kill ring and report clearly when the source file can't be located (`sayid-gen-instance-expr`, bound to `g`).

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -155,31 +155,26 @@ no value."
   [msg]
   (reply:clj->nrepl msg sd/version))
 
-(defn reply-trace-fn-at-point
-  "Resolve the qualified symbol at the cursor position described by MSG, apply
-ACTION to it when it resolves, and reply with the symbol."
-  [{:keys [file line column source] :as msg} action]
+(def fn-trace-actions
+  "Maps a trace `action' string to the workspace function that applies it to a
+qualified function symbol."
+  {"add-outer" sd/ws-add-trace-fn!*
+   "add-inner" sd/ws-add-inner-trace-fn!*
+   "enable"    sd/ws-enable-trace-fn!
+   "disable"   sd/ws-disable-trace-fn!
+   "remove"    sd/ws-remove-trace-fn!})
+
+(defn ^:nrepl sayid-trace-fn-at-point
+  "Apply trace ACTION to the function whose symbol sits at the cursor position
+described by MSG (file/line/column/source).  Replies with the resolved symbol,
+or nil when nothing resolves there."
+  [{:keys [action file line column source] :as msg}]
   (let [sym (get-sym-at-pos-in-source file line column source)
         ns-sym (symbol (parse-ns-name-from-source source))
         qual-sym (util/resolve-to-qual-sym ns-sym sym)]
     (when qual-sym
-      (action qual-sym))
+      ((fn-trace-actions action) qual-sym))
     (reply:clj->nrepl msg qual-sym)))
-
-(defn ^:nrepl sayid-trace-fn-enable-at-point [msg]
-  (reply-trace-fn-at-point msg sd/ws-enable-trace-fn!))
-
-(defn ^:nrepl sayid-trace-fn-disable-at-point [msg]
-  (reply-trace-fn-at-point msg sd/ws-disable-trace-fn!))
-
-(defn ^:nrepl sayid-trace-fn-outer-trace-at-point [msg]
-  (reply-trace-fn-at-point msg sd/ws-add-trace-fn!*))
-
-(defn ^:nrepl sayid-trace-fn-inner-trace-at-point [msg]
-  (reply-trace-fn-at-point msg sd/ws-add-inner-trace-fn!*))
-
-(defn ^:nrepl sayid-remove-trace-fn-at-point [msg]
-  (reply-trace-fn-at-point msg sd/ws-remove-trace-fn!))
 
 (defn tree-contains-inner-trace?
   [tree]
@@ -289,43 +284,20 @@ ACTION to it when it resolves, and reply with the symbol."
            (reply:clj->nrepl msg $)))
 
 (defn ^:nrepl sayid-trace-fn
-  [{:keys [transport fn-name fn-ns type] :as msg}]
-  (case type
-        "outer" (sd/ws-add-trace-fn!* (util/qualify-sym fn-ns fn-name))
-        "inner" (sd/ws-add-inner-trace-fn!* (util/qualify-sym fn-ns fn-name)))
+  "Apply trace ACTION to the function named by MSG's fn-ns/fn-name."
+  [{:keys [action fn-name fn-ns] :as msg}]
+  ((fn-trace-actions action) (util/qualify-sym fn-ns fn-name))
   (send-status-done msg))
 
-(defn reply-trace-fn
-  "Apply ACTION to the function named by MSG's fn-ns/fn-name, then end the op."
-  [{:keys [fn-name fn-ns] :as msg} action]
-  (action (util/qualify-sym fn-ns fn-name))
-  (send-status-done msg))
-
-(defn ^:nrepl sayid-trace-fn-enable [msg]
-  (reply-trace-fn msg sd/ws-enable-trace-fn!))
-
-(defn ^:nrepl sayid-trace-fn-disable [msg]
-  (reply-trace-fn msg sd/ws-disable-trace-fn!))
-
-(defn ^:nrepl sayid-trace-fn-remove [msg]
-  (reply-trace-fn msg sd/ws-remove-trace-fn!))
-
-;; NOTE: these aren't folded into a shared helper like the trace-fn ops above
-;; because `ws-remove-trace-ns!' is a macro that captures its argument's literal
-;; form, so it can't be passed as a value.
-(defn ^:nrepl sayid-trace-ns-enable
-  [{:keys [fn-ns] :as msg}]
-  (sd/ws-enable-trace-ns! (symbol fn-ns))
-  (send-status-done msg))
-
-(defn ^:nrepl sayid-trace-ns-disable
-  [{:keys [fn-ns] :as msg}]
-  (sd/ws-disable-trace-ns! (symbol fn-ns))
-  (send-status-done msg))
-
-(defn ^:nrepl sayid-trace-ns-remove
-  [{:keys [fn-ns] :as msg}]
-  (sd/ws-remove-trace-ns! (symbol fn-ns))
+;; `ws-remove-trace-ns!' is a macro that captures its argument's literal form,
+;; so the namespace actions can't be table-driven the way the fn ones are.
+(defn ^:nrepl sayid-trace-ns
+  "Apply trace ACTION (enable/disable/remove) to the namespace named by MSG's ns."
+  [{:keys [action ns] :as msg}]
+  (case action
+    "enable"  (sd/ws-enable-trace-ns! (symbol ns))
+    "disable" (sd/ws-disable-trace-ns! (symbol ns))
+    "remove"  (sd/ws-remove-trace-ns! (symbol ns)))
   (send-status-done msg))
 
 (defn ^:nrepl sayid-query-form-at-point
@@ -515,19 +487,13 @@ ACTION to it when it resolves, and reply with the symbol."
        sd/ws-add-trace-ns!*)
   (send-status-done msg))
 
-(defn ^:nrepl sayid-remove-all-traces
-  [{:keys [transport] :as msg}]
-  (sd/ws-remove-all-traces!)
-  (send-status-done msg))
-
-(defn ^:nrepl sayid-disable-all-traces
-  [{:keys [transport] :as msg}]
-  (sd/ws-disable-all-traces!)
-  (send-status-done msg))
-
-(defn ^:nrepl sayid-enable-all-traces
-  [{:keys [transport] :as msg}]
-  (sd/ws-enable-all-traces!)
+(defn ^:nrepl sayid-all-traces
+  "Apply trace ACTION (enable/disable/remove) to every trace at once."
+  [{:keys [action] :as msg}]
+  (case action
+    "enable"  (sd/ws-enable-all-traces!)
+    "disable" (sd/ws-disable-all-traces!)
+    "remove"  (sd/ws-remove-all-traces!))
   (send-status-done msg))
 
 (defn ^:nrepl sayid-get-workspace

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -342,7 +342,8 @@ state.  POS is the position to move cursor to."
 (defun sayid-trace-fn-enable ()
   "Enable tracing for symbol at point.  Symbol should point to a fn var."
   (interactive)
-  (sayid-send-and-message (list "op" "sayid-trace-fn-enable-at-point"
+  (sayid-send-and-message (list "op" "sayid-trace-fn-at-point"
+                                "action" "enable"
                                 "file" (buffer-file-name)
                                 "line" (line-number-at-pos)
                                 "column" (+ (current-column) 1)
@@ -354,7 +355,8 @@ state.  POS is the position to move cursor to."
 (defun sayid-trace-fn-disable ()
   "Disable tracing for symbol at point.  Symbol should point to a fn var."
   (interactive)
-  (sayid-send-and-message (list "op" "sayid-trace-fn-disable-at-point"
+  (sayid-send-and-message (list "op" "sayid-trace-fn-at-point"
+                                "action" "disable"
                                 "file" (buffer-file-name)
                                 "line" (line-number-at-pos)
                                 "column" (+ (current-column) 1)
@@ -366,7 +368,8 @@ state.  POS is the position to move cursor to."
 (defun sayid-outer-trace-fn ()
   "Add outer tracing for symbol at point.  Symbol should point to a fn var."
   (interactive)
-  (sayid-send-and-message (list "op" "sayid-trace-fn-outer-trace-at-point"
+  (sayid-send-and-message (list "op" "sayid-trace-fn-at-point"
+                                "action" "add-outer"
                                 "file" (buffer-file-name)
                                 "line" (line-number-at-pos)
                                 "column" (+ (current-column) 1)
@@ -378,7 +381,8 @@ state.  POS is the position to move cursor to."
 (defun sayid-inner-trace-fn ()
   "Add inner tracing for symbol at point.  Symbol should point to a fn var."
   (interactive)
-  (sayid-send-and-message (list "op" "sayid-trace-fn-inner-trace-at-point"
+  (sayid-send-and-message (list "op" "sayid-trace-fn-at-point"
+                                "action" "add-inner"
                                 "file" (buffer-file-name)
                                 "line" (line-number-at-pos)
                                 "column" (+ (current-column) 1)
@@ -390,7 +394,8 @@ state.  POS is the position to move cursor to."
 (defun sayid-remove-trace-fn ()
   "Remove tracing for symbol at point.  Symbol should point to a fn var."
   (interactive)
-  (sayid-send-and-message (list "op" "sayid-remove-trace-fn-at-point"
+  (sayid-send-and-message (list "op" "sayid-trace-fn-at-point"
+                                "action" "remove"
                                 "file" (buffer-file-name)
                                 "line" (line-number-at-pos)
                                 "column" (+ (current-column) 1)
@@ -597,14 +602,14 @@ Either navigate to ns view or function source."
 (defun sayid-trace-enable-all ()
   "Enable all traces."
   (interactive)
-  (sayid--send-sync-request (list "op" "sayid-enable-all-traces"))
+  (sayid--send-sync-request (list "op" "sayid-all-traces" "action" "enable"))
   (sayid-show-traced))
 
 ;;;###autoload
 (defun sayid-trace-disable-all ()
   "Disable all traces."
   (interactive)
-  (sayid--send-sync-request (list "op" "sayid-disable-all-traces"))
+  (sayid--send-sync-request (list "op" "sayid-all-traces" "action" "disable"))
   (sayid-show-traced))
 
 ;;;###autoload
@@ -617,7 +622,7 @@ Either navigate to ns view or function source."
     (sayid--send-sync-request (list "op" "sayid-trace-fn"
                                     "fn-name" (get-text-property (point) 'name)
                                     "fn-ns" (get-text-property (point) 'ns)
-                                    "type" "inner"))
+                                    "action" "add-inner"))
     (sayid-show-traced ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -632,7 +637,7 @@ Either navigate to ns view or function source."
     (sayid--send-sync-request (list "op" "sayid-trace-fn"
                                     "fn-name" (get-text-property (point) 'name)
                                     "fn-ns" (get-text-property (point) 'ns)
-                                    "type" "outer"))
+                                    "action" "add-outer"))
     (sayid-show-traced ns)
     (goto-char pos)))
 
@@ -646,11 +651,11 @@ Either navigate to ns view or function source."
         (fn-ns (get-text-property (point) 'ns)))
     (sayid-select-traced-buf)
     (if fn-name
-        (sayid--send-sync-request (list "op" "sayid-trace-fn-enable"
+        (sayid--send-sync-request (list "op" "sayid-trace-fn" "action" "enable"
 					"fn-name" fn-name
 					"fn-ns" fn-ns))
-      (sayid--send-sync-request (list "op" "sayid-trace-ns-enable"
-                                      "fn-ns" fn-ns)))
+      (sayid--send-sync-request (list "op" "sayid-trace-ns" "action" "enable"
+                                      "ns" fn-ns)))
     (sayid-show-traced buf-ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -665,11 +670,11 @@ Either navigate to ns view or function source."
         (fn-ns (get-text-property (point) 'ns)))
     (sayid-select-traced-buf)
     (if fn-name
-        (sayid--send-sync-request (list "op" "sayid-trace-fn-disable"
+        (sayid--send-sync-request (list "op" "sayid-trace-fn" "action" "disable"
 					"fn-name" (get-text-property (point) 'name)
 					"fn-ns" (get-text-property (point) 'ns)))
-      (sayid--send-sync-request (list "op" "sayid-trace-ns-disable"
-                                      "fn-ns" fn-ns)))
+      (sayid--send-sync-request (list "op" "sayid-trace-ns" "action" "disable"
+                                      "ns" fn-ns)))
     (sayid-show-traced buf-ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -683,11 +688,11 @@ Either navigate to ns view or function source."
         (fn-name (get-text-property (point) 'name)))
     (sayid-select-traced-buf)
     (if fn-name
-        (sayid--send-sync-request (list "op" "sayid-trace-fn-remove"
+        (sayid--send-sync-request (list "op" "sayid-trace-fn" "action" "remove"
 					"fn-name" fn-name
 					"fn-ns" (get-text-property (point) 'ns)))
-      (sayid--send-sync-request (list "op" "sayid-trace-ns-remove"
-                                      "fn-ns" (get-text-property (point) 'ns))))
+      (sayid--send-sync-request (list "op" "sayid-trace-ns" "action" "remove"
+                                      "ns" (get-text-property (point) 'ns))))
     (sayid-show-traced ns)
     (goto-char pos)
     (sayid-select-default-buf)))
@@ -696,7 +701,7 @@ Either navigate to ns view or function source."
 (defun sayid-kill-all-traces ()
   "Kill all traces."
   (interactive)
-  (sayid--send-sync-request (list "op" "sayid-remove-all-traces"))
+  (sayid--send-sync-request (list "op" "sayid-all-traces" "action" "remove"))
   (message "Killed all traces."))
 
 ;;;###autoload

--- a/test/com/billpiel/sayid/nrepl_middleware_test.clj
+++ b/test/com/billpiel/sayid/nrepl_middleware_test.clj
@@ -25,6 +25,22 @@
   (t/is (every? var? (vals mw/sayid-nrepl-ops))
         "ops resolve to vars"))
 
+(t/deftest consolidated-trace-ops-registered
+  (t/is (every? (set (keys mw/sayid-nrepl-ops))
+                ["sayid-trace-fn" "sayid-trace-fn-at-point"
+                 "sayid-trace-ns" "sayid-all-traces"])
+        "the action-parametrized trace ops are registered"))
+
+(t/deftest unknown-action-is-an-error-not-a-hang
+  (t/testing "an unrecognized action yields an error status, still terminated"
+    (let [sent (atom [])
+          handler (mw/wrap-sayid (fn [_] :unhandled))]
+      (handler {:op "sayid-trace-ns" :action "bogus" :ns "whatever"
+                :transport (recording-transport sent)})
+      (let [statuses (->> @sent (keep :status) (apply concat) set)]
+        (t/is (contains? statuses :error))
+        (t/is (contains? statuses :done))))))
+
 (t/deftest wrap-sayid-is-a-middleware
   (t/is (fn? mw/wrap-sayid))
   (t/testing "unknown ops are passed through to the wrapped handler"


### PR DESCRIPTION
Follow-up to the ops audit. The 15 trace-management ops were a combinatorial grid of (target) × (action) - five "at point" ops, four named-fn ops, three named-ns ops, three global ops - each baking one action into its own op name.

Folded into four `action`-parametrized ops:

```
sayid-trace-fn-at-point  {action, file, line, column, source}
sayid-trace-fn           {action, fn-ns, fn-name}
sayid-trace-ns           {action, ns}
sayid-all-traces         {action}
```

Shared action vocabulary: `add-outer`, `add-inner`, `enable`, `disable`, `remove` (namespaces and the global op take only enable/disable/remove). Also renamed the namespace ops' `fn-ns` key to the more accurate `ns`.

This drops the middleware from 37 ops to 26. Breaking for any third-party nREPL client, but the bundled Emacs client is updated in lockstep (and there are no other known clients).

Verified against a live nREPL server: every op/action combination replies cleanly with `:done`, the at-point op still returns the resolved symbol so the client can report what it traced, and an unknown action degrades to an `:error` status rather than hanging. Added regression tests for registration and the unknown-action path. Full suite + kondo green.