### PR TITLE
Document the nREPL middleware API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [#13](https://github.com/clojure-emacs/sayid/issues/13): Document the nREPL middleware API (see [doc/nrepl-api.md](doc/nrepl-api.md)).
 * Consolidate the trace-management nREPL ops into four `action`-parametrized ops (`sayid-trace-fn`, `sayid-trace-fn-at-point`, `sayid-trace-ns`, `sayid-all-traces`), trimming the middleware from 37 ops to 26. (Breaking for any third-party nREPL client; the bundled Emacs client is updated in lockstep.)
 * [#29](https://github.com/clojure-emacs/sayid/issues/29): Fix the `wrong-type-argument` error when pressing `g` (and similar commands) by no longer re-reading nREPL response values, which already arrive decoded on nREPL 1.0+.
 * [#14](https://github.com/clojure-emacs/sayid/issues/14): Fix inner tracing of functions that use `letfn`.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ on Emacs 28+.
 Clojure versions may still work, but they're no longer part of the test matrix.)
 
 nREPL-powered editor plugins are encouraged to make use of the bundled middleware that
-provides a very flexible Sayid API.
+provides a very flexible Sayid API. Its ops are documented in
+[doc/nrepl-api.md](doc/nrepl-api.md).
 
 ### Leiningen
 

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -1,0 +1,237 @@
+# Sayid nREPL API
+
+Sayid ships an nREPL middleware (`com.billpiel.sayid.nrepl-middleware/wrap-sayid`)
+that exposes its tracing engine over the wire. The bundled Emacs client talks to
+Sayid exclusively through these ops, and any other editor or tool can do the same.
+
+This document is the reference for that wire API.
+
+## Loading the middleware
+
+With Leiningen, add Sayid as a plugin (it registers the middleware automatically):
+
+```clojure
+{:user {:plugins [[com.billpiel/sayid "0.1.0"]]}}
+```
+
+Or add the middleware explicitly when you start the server, e.g. with the
+Clojure CLI / `nrepl.server`:
+
+```clojure
+(nrepl.server/start-server
+ :handler (nrepl.server/default-handler #'com.billpiel.sayid.nrepl-middleware/wrap-sayid))
+```
+
+## Conventions
+
+Send a normal nREPL message with an `"op"` key naming one of the ops below, plus
+whatever parameters that op takes. Every op terminates the request with a
+`:status` of `"done"`, so a synchronous client can block until it arrives.
+
+Ops fall into two shapes:
+
+- **Command ops** just do their work and reply with `:status "done"` (no value).
+- **Query ops** reply with a `:value`, then `:status "done"`.
+
+Response **values are already decoded** - Sayid encodes them into plain
+bencode-friendly data (nested lists, strings and numbers) before they go on the
+wire, so by the time your nREPL client hands you a value it is ordinary data. Do
+**not** run it through a reader. A few encoding rules are worth knowing:
+
+- keywords arrive as their bare name strings (`:foo` -> `"foo"`),
+- booleans arrive as `1` / `nil`,
+- anything Sayid can't represent structurally arrives as its printed string.
+
+If an op throws, the response carries `:status #{"error" "done"}` along with
+`:err` (a stack trace) and `:ex` (the exception class), the same convention
+cider-nrepl uses, so the failure surfaces instead of hanging the client.
+
+Several ops resolve "the thing at the cursor" server-side. They take the buffer
+`source` (the whole file as a string) plus a 1-based `line` and `column`, and
+Sayid parses the source to find the symbol there. This keeps editors from having
+to reimplement Clojure-aware symbol resolution.
+
+## Applying and managing traces
+
+### `sayid-trace-fn-at-point`
+
+Apply a trace action to the function whose symbol is at the cursor.
+
+| param | meaning |
+|-------|---------|
+| `action` | one of `add-outer`, `add-inner`, `enable`, `disable`, `remove` |
+| `file` | path of the buffer's file |
+| `line`, `column` | 1-based cursor position |
+| `source` | the buffer's full text |
+
+Replies with the resolved qualified symbol (e.g. `"my.ns/my-fn"`), or `nil` when
+nothing resolves at that position.
+
+### `sayid-trace-fn`
+
+Apply a trace action to an explicitly named function.
+
+| param | meaning |
+|-------|---------|
+| `action` | one of `add-outer`, `add-inner`, `enable`, `disable`, `remove` |
+| `fn-ns` | the function's namespace |
+| `fn-name` | the function's name |
+
+`add-outer` records calls to the function; `add-inner` additionally records every
+expression evaluated inside it. `enable`/`disable` flip an existing trace on and
+off; `remove` tears it down. Replies with `:status "done"`.
+
+### `sayid-trace-ns`
+
+Apply a trace action to a whole namespace.
+
+| param | meaning |
+|-------|---------|
+| `action` | one of `enable`, `disable`, `remove` |
+| `ns` | the namespace name |
+
+Replies with `:status "done"`.
+
+### `sayid-all-traces`
+
+Apply a trace action to every trace at once.
+
+| param | meaning |
+|-------|---------|
+| `action` | one of `enable`, `disable`, `remove` |
+
+Replies with `:status "done"`.
+
+### `sayid-trace-ns-in-file`
+
+Trace the namespace declared in `file`. Param: `file`. Replies `:status "done"`.
+
+### `sayid-trace-ns-by-pattern`
+
+Trace every loaded namespace whose name matches a pattern.
+
+| param | meaning |
+|-------|---------|
+| `ns-pattern` | a namespace pattern, where `*` is a wildcard |
+| `ref-ns` | a namespace to resolve the pattern relative to |
+
+Replies with `:status "done"`.
+
+### `sayid-trace-all-ns-in-dir`
+
+Recursively trace every namespace found under `dir`. Param: `dir`. Replies
+`:status "done"`.
+
+## Inspecting recorded calls
+
+### `sayid-get-workspace`
+
+Render the current workspace with the active view. Takes no params. Replies with
+the rendered tree as a `[text text-properties query-args]` triple, where `text`
+is the printable output, `text-properties` describes per-span coloring/metadata,
+and `query-args` is the printed query that produced it.
+
+### `sayid-query`
+
+Run a query against the workspace. Param: `query` (a printed Clojure query
+form). Replies with the same `[text properties query-args]` triple as
+`sayid-get-workspace`.
+
+### `sayid-query-form-at-point`
+
+Query the workspace for the calls that best match the cursor context. Params:
+`file`, `line`. Replies with a `[text properties]` pair.
+
+### `sayid-buf-query-id-w-mod`
+
+Query for a recorded call by id, optionally with a modifier.
+
+| param | meaning |
+|-------|---------|
+| `trace-id` | the id of the recorded call |
+| `mod` | a modifier string, e.g. `"a"` (ancestors), `"d"` (descendants), optionally with a depth |
+
+Replies with a `[text properties query-args]` triple.
+
+### `sayid-buf-query-fn-w-mod`
+
+Like the above, but selects by function name. Params: `fn-name`, `mod`. Replies
+with a `[text properties query-args]` triple.
+
+## Acting on a recorded call
+
+These operate on a single node in the rendered output, identified by `trace-id`
+(and `path` for nested values).
+
+### `sayid-gen-instance-expr`
+
+Generate an expression that reproduces a recorded call, def-ing its arguments to
+`$s/*` vars along the way. Param: `trace-id`. Replies with the expression string
+(e.g. `"(my.ns/my-fn $s/a $s/b)"`).
+
+### `sayid-buf-def-at-point`
+
+Def the value at `path` within the call `trace-id` to `$s/*`. Params: `trace-id`,
+`path`. Replies with a confirmation value.
+
+### `sayid-buf-pprint-at-point`
+
+Pretty-print the value at `path` within the call `trace-id`. Params: `trace-id`,
+`path`. Replies with the pretty-printed text.
+
+## Views
+
+### `sayid-set-view`
+
+Select a named view for subsequent rendering. Param: `view-name`. Replies
+`:status "done"`.
+
+### `sayid-toggle-view`
+
+Toggle between the default and the verbose view. Takes no params. Replies with
+the new state.
+
+### `sayid-get-views`
+
+List the registered view names. Takes no params. Replies with the view names.
+
+## Workspace lifecycle
+
+### `sayid-clear-log`
+
+Clear the recorded calls but keep the traces in place. Takes no params. Replies
+`:status "done"`.
+
+### `sayid-reset-workspace`
+
+Remove all traces and clear the recorded calls. Takes no params. Replies
+`:status "done"`.
+
+## Introspection
+
+### `sayid-version`
+
+Replies with the Sayid version string (e.g. `"0.1.0"`).
+
+### `sayid-get-trace-count`
+
+Replies with the number of traces in the workspace.
+
+### `sayid-get-enabled-trace-count`
+
+Replies with the number of currently enabled traces.
+
+### `sayid-get-meta-at-point`
+
+Resolve the symbol at the cursor and report its metadata. Params: `source`,
+`file`, `line`.
+
+### `sayid-find-all-ns-roots`
+
+Replies with the distinct source roots of the loaded namespaces (e.g.
+`["src" "test"]`), handy for offering a directory to scan.
+
+### `sayid-show-traced`
+
+Render the list of what's currently traced. Optional param: `ns` (limit to one
+namespace). Replies with the rendered tree.


### PR DESCRIPTION
Fixes #13.

Adds `doc/nrepl-api.md` - a reference for the bundled middleware's ops, grouped by purpose (applying/managing traces, inspecting recorded calls, acting on a call, views, workspace lifecycle, introspection), with each op's parameters and what it replies.

It also documents the response conventions a non-Emacs client needs but that were nowhere written down: the done/value/error message shapes, and that values arrive already decoded (no reader needed) - the same thing that bit us in #29. Linked from the README. Params verified against the source and the live server.