### PR TITLE
Rename buffer-oriented nREPL ops to client-agnostic names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#13](https://github.com/clojure-emacs/sayid/issues/13): Document the nREPL middleware API (see [doc/nrepl-api.md](doc/nrepl-api.md)).
 * Rewrite the README's demo walkthrough around a small, self-contained example with current keybindings.
 * Consolidate the trace-management nREPL ops into four `action`-parametrized ops (`sayid-trace-fn`, `sayid-trace-fn-at-point`, `sayid-trace-ns`, `sayid-all-traces`), trimming the middleware from 37 ops to 26. (Breaking for any third-party nREPL client; the bundled Emacs client is updated in lockstep.)
+* Rename the buffer-oriented nREPL ops to client-agnostic names: `sayid-buf-query-id-w-mod` -> `sayid-query-by-id`, `sayid-buf-query-fn-w-mod` -> `sayid-query-by-fn`, `sayid-buf-def-at-point` -> `sayid-def-value`, `sayid-buf-pprint-at-point` -> `sayid-pprint-value`.
 * [#29](https://github.com/clojure-emacs/sayid/issues/29): Fix the `wrong-type-argument` error when pressing `g` (and similar commands) by no longer re-reading nREPL response values, which already arrive decoded on nREPL 1.0+.
 * [#14](https://github.com/clojure-emacs/sayid/issues/14): Fix inner tracing of functions that use `letfn`.
 * [#31](https://github.com/clojure-emacs/sayid/issues/31): Keep the generated reproduction expression in the kill ring and report clearly when the source file can't be located (`sayid-gen-instance-expr`, bound to `g`).

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -142,7 +142,7 @@ form). Replies with the same `[text properties query-args]` triple as
 Query the workspace for the calls that best match the cursor context. Params:
 `file`, `line`. Replies with a `[text properties]` pair.
 
-### `sayid-buf-query-id-w-mod`
+### `sayid-query-by-id`
 
 Query for a recorded call by id, optionally with a modifier.
 
@@ -153,7 +153,7 @@ Query for a recorded call by id, optionally with a modifier.
 
 Replies with a `[text properties query-args]` triple.
 
-### `sayid-buf-query-fn-w-mod`
+### `sayid-query-by-fn`
 
 Like the above, but selects by function name. Params: `fn-name`, `mod`. Replies
 with a `[text properties query-args]` triple.
@@ -169,12 +169,12 @@ Generate an expression that reproduces a recorded call, def-ing its arguments to
 `$s/*` vars along the way. Param: `trace-id`. Replies with the expression string
 (e.g. `"(my.ns/my-fn $s/a $s/b)"`).
 
-### `sayid-buf-def-at-point`
+### `sayid-def-value`
 
 Def the value at `path` within the call `trace-id` to `$s/*`. Params: `trace-id`,
 `path`. Replies with a confirmation value.
 
-### `sayid-buf-pprint-at-point`
+### `sayid-pprint-value`
 
 Pretty-print the value at `path` within the call `trace-id`. Params: `trace-id`,
 `path`. Replies with the pretty-printed text.

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -316,7 +316,7 @@ or nil when nothing resolves there."
                        (apply query*)
                        query-tree->trio))))
 
-(defn ^:nrepl sayid-buf-query-id-w-mod
+(defn ^:nrepl sayid-query-by-id
   [{:keys [trace-id mod] :as msg}]
   (reply:clj->nrepl msg
                     (sayid-buf-query [:id (keyword trace-id)]
@@ -324,7 +324,7 @@ or nil when nothing resolves there."
 
 (def parent-name-or-name (some-fn :parent-name :name))
 
-(defn ^:nrepl sayid-buf-query-fn-w-mod
+(defn ^:nrepl sayid-query-by-fn
   [{:keys [fn-name mod] :as msg}]
   (reply:clj->nrepl msg (sayid-buf-query [#'parent-name-or-name
                                           (symbol fn-name)]
@@ -427,7 +427,7 @@ or nil when nothing resolves there."
             (reply:clj->nrepl msg))
       (send-status-done msg)))
 
-(defn ^:nrepl sayid-buf-def-at-point
+(defn ^:nrepl sayid-def-value
   [{:keys [transport trace-id path] :as msg}]
   (let [path' (str-vec->arg-path path)]
     (util/def-ns-var '$s '* (-> [:id (keyword trace-id)]
@@ -438,7 +438,7 @@ or nil when nothing resolves there."
   (t/send transport (response-for msg :value "Def'd as $s/*"))
   (send-status-done msg))
 
-(defn ^:nrepl sayid-buf-pprint-at-point
+(defn ^:nrepl sayid-pprint-value
   [{:keys [transport trace-id path] :as msg}]
   (let [path' (str-vec->arg-path path)
         value (-> [:id (keyword trace-id)]

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -765,7 +765,7 @@ Either navigate to ns view or function source."
 (defun sayid-query-id-w-mod ()
   "Query workspace for id, with optional modifier."
   (interactive)
-  (sayid-req-insert-content (list "op" "sayid-buf-query-id-w-mod"
+  (sayid-req-insert-content (list "op" "sayid-query-by-id"
                                   "trace-id" (get-text-property (point) 'id)
                                   "mod" (read-string "query modifier: "))))
 
@@ -773,7 +773,7 @@ Either navigate to ns view or function source."
 (defun sayid-query-id ()
   "Query workspace for id."
   (interactive)
-  (sayid-req-insert-content (list "op" "sayid-buf-query-id-w-mod"
+  (sayid-req-insert-content (list "op" "sayid-query-by-id"
                                   "trace-id" (get-text-property (point) 'id)
                                   "mod" "")))
 
@@ -781,7 +781,7 @@ Either navigate to ns view or function source."
 (defun sayid-query-fn-w-mod ()
   "Query workspace for function, with optional modifier."
   (interactive)
-  (sayid-req-insert-content (list "op" "sayid-buf-query-fn-w-mod"
+  (sayid-req-insert-content (list "op" "sayid-query-by-fn"
                                   "fn-name" (get-text-property (point) 'fn-name)
                                   "mod" (read-string "query modifier: "))))
 
@@ -789,7 +789,7 @@ Either navigate to ns view or function source."
 (defun sayid-query-fn ()
   "Query workspace for function."
   (interactive)
-  (sayid-req-insert-content (list "op" "sayid-buf-query-fn-w-mod"
+  (sayid-req-insert-content (list "op" "sayid-query-by-fn"
                                   "fn-name" (get-text-property (point) 'fn-name)
                                   "mod" "")))
 
@@ -797,7 +797,7 @@ Either navigate to ns view or function source."
 (defun sayid-buf-def-at-point ()
   "Def value at point to a var."
   (interactive)
-  (sayid-send-and-message (list "op" "sayid-buf-def-at-point"
+  (sayid-send-and-message (list "op" "sayid-def-value"
                                 "trace-id" (get-text-property (point) 'id)
                                 "path" (get-text-property (point) 'path))))
 
@@ -805,7 +805,7 @@ Either navigate to ns view or function source."
 (defun sayid-buf-inspect-at-point ()
   "Def value at point and pass to `cider-inspect'."
   (interactive)
-  (sayid-send-and-message (list "op" "sayid-buf-def-at-point"
+  (sayid-send-and-message (list "op" "sayid-def-value"
                                 "trace-id" (get-text-property (point) 'id)
                                 "path" (get-text-property (point) 'path)))
   (cider-inspect "$s/*"))
@@ -815,7 +815,7 @@ Either navigate to ns view or function source."
   "Open pretty-print buffer for value at point in sayid buffer."
   (interactive)
   (sayid-select-pprint-buf)
-  (sayid-req-insert-content (list "op" "sayid-buf-pprint-at-point"
+  (sayid-req-insert-content (list "op" "sayid-pprint-value"
                                   "trace-id" (get-text-property (point) 'id)
                                   "path" (get-text-property (point) 'path)))
   (goto-char 1)


### PR DESCRIPTION
Follow-up to the ops audit. Four ops still carried Emacs jargon in their wire names - `buf-` (the *sayid* buffer) and `-w-mod` ("with modifier"):

```
sayid-buf-query-id-w-mod   -> sayid-query-by-id
sayid-buf-query-fn-w-mod   -> sayid-query-by-fn
sayid-buf-def-at-point     -> sayid-def-value
sayid-buf-pprint-at-point  -> sayid-pprint-value
```

Renamed the ops and updated the client and `doc/nrepl-api.md` to match. The Emacs *command* names are left as-is (they're legitimately Emacs functions); only the wire protocol is cleaned up. Verified against a live nREPL server - all four register and respond under the new names. Full suite + kondo green.