### PR TITLE
Release 0.2.0 under the mx.cider/sayid coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
-## unreleased
+## [0.2.0] - 2026-06-29
 
+* Publish under the `mx.cider/sayid` coordinates. The old `com.billpiel/sayid` coordinates are deprecated but still receive the same releases for now, so existing dependencies keep working.
 * [#13](https://github.com/clojure-emacs/sayid/issues/13): Document the nREPL middleware API (see [doc/nrepl-api.md](doc/nrepl-api.md)).
 * Rewrite the README's demo walkthrough around a small, self-contained example with current keybindings.
 * Consolidate the trace-management nREPL ops into four `action`-parametrized ops (`sayid-trace-fn`, `sayid-trace-fn-at-point`, `sayid-trace-ns`, `sayid-all-traces`), trimming the middleware from 37 ops to 26. (Breaking for any third-party nREPL client; the bundled Emacs client is updated in lockstep.)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ----------
 [![Clojure CI](https://github.com/clojure-emacs/sayid/actions/workflows/clojure.yml/badge.svg)](https://github.com/clojure-emacs/sayid/actions/workflows/clojure.yml)
-[![Clojars Project](https://img.shields.io/clojars/v/com.billpiel/sayid.svg)](https://clojars.org/com.billpiel/sayid)
-[![cljdoc badge](https://cljdoc.org/badge/com.billpiel/sayid)](https://cljdoc.org/d/com.billpiel/sayid/CURRENT)
+[![Clojars Project](https://img.shields.io/clojars/v/mx.cider/sayid.svg)](https://clojars.org/mx.cider/sayid)
+[![cljdoc badge](https://cljdoc.org/badge/mx.cider/sayid)](https://cljdoc.org/d/mx.cider/sayid/CURRENT)
 
 Sayid *(siy EED)* is an omniscient debugger and profiler for Clojure. It extracts secrets from code at run-time.
 
@@ -28,6 +28,12 @@ development efforts.
 
 ## Installation & Requirements
 
+> [!NOTE]
+> Starting with 0.2.0 Sayid is published under the `mx.cider/sayid` coordinates.
+> The old `com.billpiel/sayid` coordinates are deprecated but still receive the
+> same releases for now, so existing dependencies keep working. Please switch to
+> `mx.cider/sayid` when you get a chance.
+
 ### Requirements
 
 Basic usage requires Clojure 1.10+ running on Java 8 or newer. The optional
@@ -45,14 +51,14 @@ provides a very flexible Sayid API. Its ops are documented in
 
 Add this to the dependencies in your project.clj or lein profiles.clj:
 
-    [com.billpiel/sayid "0.1.0"]
+    [mx.cider/sayid "0.2.0"]
 
 To use the bundled nREPL middleware, you'll want to include Sayid as a
 plug-in. Here's an example of a bare-bones profiles.clj that works for
 me:
 
 ```clojure
-{:user {:plugins [[com.billpiel/sayid "0.1.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.2.0"]]}}
 ```
 
 ### Clojure CLI - deps.edn
@@ -63,7 +69,7 @@ tools.deps config directory (often `$HOME/.clojure`).
 
 ```clojure
 {:deps
-  {com.billpiel/sayid {:mvn/version "0.1.0"}}}
+  {mx.cider/sayid {:mvn/version "0.2.0"}}}
 ```
 
 ### Emacs Integration
@@ -88,7 +94,7 @@ that works for me:
 
 ```clojure
 {:user {:plugins [[cider/cider-nrepl "0.59.0"]
-                  [com.billpiel/sayid "0.1.0"]]
+                  [mx.cider/sayid "0.2.0"]]
         :dependencies [[nrepl/nrepl "1.3.1"]]}}
 ```
 
@@ -161,7 +167,7 @@ from within Emacs: press `h` in any Sayid buffer (or `C-c s h` in a Clojure
 buffer) to pop up the matching help buffer.
 
 API docs for the core namespaces are available on
-[cljdoc](https://cljdoc.org/d/com.billpiel/sayid/CURRENT).
+[cljdoc](https://cljdoc.org/d/mx.cider/sayid/CURRENT).
 
 In a clojure-mode buffer, press `C-c s h` (`sayid-show-help`) to
 pop up the help buffer.

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -11,7 +11,7 @@ This document is the reference for that wire API.
 With Leiningen, add Sayid as a plugin (it registers the middleware automatically):
 
 ```clojure
-{:user {:plugins [[com.billpiel/sayid "0.1.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.2.0"]]}}
 ```
 
 Or add the middleware explicitly when you start the server, e.g. with the
@@ -211,7 +211,7 @@ Remove all traces and clear the recorded calls. Takes no params. Replies
 
 ### `sayid-version`
 
-Replies with the Sayid version string (e.g. `"0.1.0"`).
+Replies with the Sayid version string (e.g. `"0.2.0"`).
 
 ### `sayid-get-trace-count`
 

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -1,0 +1,61 @@
+# Releasing Sayid
+
+Sayid ships two artifacts: the Clojure library/middleware (published to Clojars)
+and the `sayid` Emacs package (published to MELPA from the same repo). The version
+string is hardcoded in a few places rather than derived at build time, so cutting
+a release starts with bumping all of them.
+
+## 1. Bump the version
+
+Set the new version in:
+
+- `project.clj` - the `defproject` coordinate
+- `src/com/billpiel/sayid/core.clj` - `version`
+- `src/sayid/plugin.clj` - `version`
+- `src/el/sayid.el` - the `Version:` header, `sayid-version`, and `sayid-injected-plugin-version`
+- `README.md` and `doc/nrepl-api.md` - the dependency snippets
+
+## 2. Update the changelog
+
+Move the `## unreleased` heading to `## [x.y.z] - YYYY-MM-DD`.
+
+## 3. Sanity check
+
+```sh
+make test-all   # Clojure suite across the version matrix
+make kondo      # Clojure lint
+make elisp      # byte-compile + checkdoc the Emacs client
+```
+
+## 4. Deploy to Clojars
+
+Sayid is published primarily under `mx.cider/sayid`. The legacy
+`com.billpiel/sayid` coordinates are kept alive for now so existing dependencies
+don't break, so each release is deployed twice.
+
+You'll need `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` in the environment (a
+Clojars deploy token), and deploy rights on both groups.
+
+```sh
+# Primary coordinates (mx.cider/sayid), as written in project.clj:
+lein deploy clojars
+
+# Legacy coordinates (com.billpiel/sayid): deploy the same build under the old
+# group, then revert. The version is hardcoded, so the jar is identical bar the
+# pom's groupId.
+sed -i '' 's|defproject mx.cider/sayid|defproject com.billpiel/sayid|' project.clj
+lein deploy clojars
+git checkout project.clj
+```
+
+Once the legacy group is no longer worth maintaining, drop the second deploy and
+the note in the README.
+
+## 5. Tag and push
+
+```sh
+git tag -a vX.Y.Z -m "X.Y.Z"
+git push origin master --tags
+```
+
+MELPA picks up the Emacs package from the repo automatically.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.billpiel/sayid "0.1.0"
+(defproject mx.cider/sayid "0.2.0"
   :description "Sayid is a library for debugging and profiling clojure code."
   :url "https://github.com/clojure-emacs/sayid"
   :scm {:name "git" :url "https://github.com/clojure-emacs/sayid"}

--- a/src/com/billpiel/sayid/core.clj
+++ b/src/com/billpiel/sayid/core.clj
@@ -1,6 +1,5 @@
 (ns com.billpiel.sayid.core
-  (:require [clojure.java.io :as io]
-            clojure.pprint
+  (:require clojure.pprint
             [com.billpiel.sayid.trace :as trace]
             [com.billpiel.sayid.inner-trace3 :as itrace]
             [com.billpiel.sayid.workspace :as ws]
@@ -14,11 +13,7 @@
 
 (def version
   "The current version of sayid as a string."
-  (-> (or (io/resource "META-INF/leiningen/com.billpiel/sayid/project.clj")
-          "project.clj")
-      slurp
-      read-string
-      (nth 2)))
+  "0.2.0")
 
 (def workspace
   "The active workspace. Used by default in any function prefixed `ws-`

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -4,7 +4,7 @@
 
 ;; Author: Bill Piel <bill@billpiel.com>
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; URL: https://github.com/clojure-emacs/sayid
 ;; Package-Requires: ((emacs "28") (cider "1.0"))
 ;; Keywords: clojure, cider, debugger
@@ -46,98 +46,98 @@
 (defcustom sayid-inject-dependencies-at-jack-in t
   "When nil, do not inject REPL dependencies at `cider-jack-in' time.
 The injected dependencies are most likely nREPL middlewares."
-  :package-version '(sayid . "0.1.0")
+  :package-version '(sayid . "0.2.0")
   :type 'boolean)
 
 (defconst sayid-version
-  "0.1.0"
+  "0.2.0"
   "The current version of sayid.")
 
 (defconst sayid-injected-plugin-version
-  "0.1.0"
+  "0.2.0"
   "The version of the sayid Lein plugin to be automatically injected.")
 
 (defface sayid-int-face '((t :inherit default))
   "Sayid integer face."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-float-face '((t :inherit default))
   "Sayid float face."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-symbol-face '((t :inherit default))
   "Sayid symbol face."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-string-face
   '((t :inherit font-lock-string-face))
   "Sayid string face."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-keyword-face
   '((t :inherit font-lock-constant-face))
   "Sayid keyword face."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-1-face
   '((((background light)) (:foreground "Springgreen4"))
     (((background dark)) (:foreground "Palegreen1")))
   "Sayid nesting, depth 1 - outermost set."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-2-face
   '((((background light)) (:foreground "DodgerBlue"))
     (((background dark)) (:foreground "Cadetblue1")))
   "Sayid nesting, depth 2."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-3-face
   '((((background light)) (:foreground "Red1"))
     (((background dark)) (:foreground "Palevioletred1")))
   "Sayid nesting, depth 3."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-4-face
   '((((background light)) (:foreground "Orange1"))
     (((background dark)) (:foreground "Lightsalmon1")))
   "Sayid nesting, depth 4."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-5-face
   '((((background light)) (:foreground "Gold3"))
     (((background dark)) (:foreground "PaleGoldenrod")))
   "Sayid nesting, depth 5."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-6-face
   '((((background light)) (:foreground "DimGray"))
     (((background dark)) (:foreground "LightGray")))
   "Sayid nesting, depth 6."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-7-face
   '((((background light)) (:foreground "Mediumpurple3"))
     (((background dark)) (:foreground "Lightpink1")))
   "Sayid nesting, depth 7."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-8-face
   '((((background light)) (:foreground "DarkTurquoise"))
     (((background dark)) (:foreground "Paleturquoise1")))
   "Sayid nesting, depth 8."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-9-face
   '((((background light)) (:foreground "Peachpuff3"))
     (((background dark)) (:foreground "Peachpuff1")))
   "Sayid nesting, depth 9."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defface sayid-depth-10-face
   '((((background light)) (:foreground "IndianRed"))
     (((background dark)) (:foreground "MistyRose")))
   "Sayid nesting, depth 10."
-  :package-version '(sayid . "0.1.0"))
+  :package-version '(sayid . "0.2.0"))
 
 (defvar sayid-trace-ns-dir nil)
 (defvar sayid-meta nil)
@@ -161,10 +161,10 @@ To opt out, set `sayid-inject-dependencies-at-jack-in' to nil."
     ;; any existing entry for the artifact, so this stays idempotent.
     (when (boundp 'cider-jack-in-lein-plugins)
       (cider-add-to-alist 'cider-jack-in-lein-plugins
-                          "com.billpiel/sayid" sayid-injected-plugin-version))
+                          "mx.cider/sayid" sayid-injected-plugin-version))
     (when (boundp 'cider-jack-in-dependencies)
       (cider-add-to-alist 'cider-jack-in-dependencies
-                          "com.billpiel/sayid" sayid-injected-plugin-version))
+                          "mx.cider/sayid" sayid-injected-plugin-version))
     (add-to-list 'cider-jack-in-nrepl-middlewares "com.billpiel.sayid.nrepl-middleware/wrap-sayid")))
 
 ;;;###autoload
@@ -254,7 +254,7 @@ Signal a `user-error' with actionable guidance otherwise."
   (unless (cider-connected-p)
     (user-error "Sayid: no active nREPL connection; start a REPL with `cider-jack-in'"))
   (unless (cider-nrepl-op-supported-p "sayid-get-workspace")
-    (user-error "Sayid: nREPL middleware not loaded; add `com.billpiel/sayid' to your plugins and restart the REPL")))
+    (user-error "Sayid: nREPL middleware not loaded; add `mx.cider/sayid' to your plugins and restart the REPL")))
 
 (defun sayid--send-sync-request (request)
   "Send REQUEST to the Sayid nREPL middleware and return the response.

--- a/src/sayid/plugin.clj
+++ b/src/sayid/plugin.clj
@@ -1,21 +1,15 @@
-(ns sayid.plugin
-  (:require
-   [clojure.java.io :as io]))
+(ns sayid.plugin)
 
 (def version
   "The current version of sayid as a string."
-  (-> (or (io/resource  "META-INF/leiningen/com.billpiel/sayid/project.clj")
-          "project.clj")
-      slurp
-      read-string
-      (nth 2)))
+  "0.2.0")
 
 (defn middleware
   [project]
   (-> project
       (update-in [:dependencies]
                  (fnil into [])
-                 [['com.billpiel/sayid version]])
+                 [['mx.cider/sayid version]])
       (update-in [:repl-options :nrepl-middleware]
                  (fnil into [])
                  ['com.billpiel.sayid.nrepl-middleware/wrap-sayid])))


### PR DESCRIPTION
Cuts the 0.2.0 release and moves Sayid to the `mx.cider/sayid` coordinates.

- New coordinates `mx.cider/sayid`; the old `com.billpiel/sayid` stays alive (each release deployed under both) so existing deps keep working. README + CHANGELOG point people at the new ones.
- Hardcoded the Clojure-side `version` (was slurped from the jar's embedded `project.clj`, which is keyed on the artifact path and would break under a second coordinate). The same jar now works under either coordinate.
- Bumped the version to 0.2.0 everywhere; turned the unreleased changelog into the 0.2.0 entry.
- Added `doc/releasing.md` documenting the process, including the dual deploy.

The actual Clojars publish is a manual step (credentials) - see doc/releasing.md. Build verified locally: full suite, kondo, and the Emacs byte-compile/lint all green, and `lein pom` produces `mx.cider/sayid` 0.2.0.