### PR TITLE
Fix latent bugs in the Emacs client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## unreleased
+
+* [#86](https://github.com/clojure-emacs/sayid/pull/86): Fix a state leak in the traced-buffer outer-trace command, a crash when navigating to a numeric trace id, and a couple of messages that broke on a literal `%` in a path.
+
 ## [0.2.0] - 2026-06-29
 
 * Publish under the `mx.cider/sayid` coordinates. The old `com.billpiel/sayid` coordinates are deprecated but still receive the same releases for now, so existing dependencies keep working.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -277,7 +277,7 @@ resolved automatically."
   (let ((p 1))
     (while (and p
                 (<= p (point-max)))
-      (if (string= val (get-text-property p prop))
+      (if (equal val (get-text-property p prop))
           (progn
             (goto-char p)
             (setq p (+ 1 (point-max))))
@@ -639,7 +639,8 @@ Either navigate to ns view or function source."
                                     "fn-ns" (get-text-property (point) 'ns)
                                     "action" "add-outer"))
     (sayid-show-traced ns)
-    (goto-char pos)))
+    (goto-char pos)
+    (sayid-select-default-buf)))
 
 ;;;###autoload
 (defun sayid-traced-buf-enable ()
@@ -741,7 +742,7 @@ Either navigate to ns view or function source."
           (pop-to-buffer (find-file-noselect xfile))
           (goto-char (point-min))
           (forward-line (- line 1)))
-      (message (concat "File not found: " file)))))
+      (user-error "File not found: %s" file))))
 
 ;;;###autoload
 (defun sayid-buffer-nav-to-prev ()
@@ -849,7 +850,7 @@ Either navigate to ns view or function source."
 (defun sayid-pprint-buf-show-path ()
   "Show path to value at point in pretty-print buffer."
   (interactive)
-  (message (get-text-property (point) 'path)))
+  (message "%s" (get-text-property (point) 'path)))
 
 (defun sayid-get-views ()
   "List of installed views."

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -64,5 +64,23 @@
     (expect (sayid-cycle-ring-back) :to-be :a)
     (expect sayid-ring :to-equal '(:a :b :c))))
 
+(describe "sayid-try-goto-prop"
+  (it "moves point to the first span whose property equals VAL, even for numeric values"
+    ;; Regression: `id' values arrive as numbers, so comparing them with
+    ;; `string=' used to crash with a wrong-type error.
+    (with-temp-buffer
+      (insert "abcdef")
+      (put-text-property 3 5 'id 42)
+      (goto-char (point-min))
+      (sayid-try-goto-prop 'id 42)
+      (expect (point) :to-equal 3)))
+
+  (it "leaves point untouched when no span matches"
+    (with-temp-buffer
+      (insert "abcdef")
+      (goto-char 4)
+      (sayid-try-goto-prop 'id 99)
+      (expect (point) :to-equal 4))))
+
 (provide 'sayid-test)
 ;;; sayid-test.el ends here


### PR DESCRIPTION
First pass from the Elisp audit: a few real bugs, with a regression test for the one that's cleanly unit-testable.

- `sayid-traced-buf-outer-trace-fn` didn't reset Sayid's selected buffer the way its four siblings do, leaving later operations pointed at the trace buffer.
- `sayid-try-goto-prop` compared numeric `id` properties with `string=`, which crashes on non-strings - switched to `equal`.
- Two messages built their text via `concat`/raw property values, so a `%` in a path or filename would error or misformat. They now use format strings, and the missing-file case signals a `user-error`.

Cleanup of the duplication and idiom issues the audit found will follow in separate PRs.