### PR TITLE
Run the Emacs Lisp CI inside silex/emacs containers

### DIFF
--- a/.github/workflows/elisp.yml
+++ b/.github/workflows/elisp.yml
@@ -7,35 +7,26 @@ on:
   pull_request:
 
 jobs:
-  compile:
+  test:
     runs-on: ubuntu-latest
-    # `snapshot` is Emacs built from git master; treat it as informational so an
-    # unreleased-Emacs hiccup (or a flaky install) can't block a merge.
-    continue-on-error: ${{ matrix.emacs_version == 'snapshot' }}
+    # Run inside the prebuilt silex/emacs images (Emacs + Eldev, no nix). This
+    # avoids the nix-emacs-ci setup that kept tripping GitHub's unauthenticated
+    # API rate limit (HTTP 429) on every run.
+    container:
+      image: silex/emacs:${{ matrix.emacs_version }}-ci-eldev
+    # `master` is Emacs built from git; treat it as informational so an
+    # unreleased-Emacs hiccup can't block a merge.
+    continue-on-error: ${{ matrix.emacs_version == 'master' }}
     strategy:
       fail-fast: false
-      # Install one Emacs at a time so the concurrent nix installs don't burst
-      # the (unauthenticated) GitHub API rate limit and 429.
-      max-parallel: 1
       matrix:
         emacs_version:
           - '28.2'
           - '29.4'
-          - '30.2'
-          - 'snapshot'
-    env:
-      # setup-emacs fetches nix-emacs-ci from GitHub; without a token nix uses
-      # unauthenticated API calls that get rate-limited (HTTP 429). Hand it the
-      # workflow token so the requests are authenticated.
-      NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+          - '30.1'
+          - 'master'
     steps:
       - uses: actions/checkout@v4
-
-      - uses: jcs090218/setup-emacs@master
-        with:
-          version: ${{ matrix.emacs_version }}
-
-      - uses: emacs-eldev/setup-eldev@v1
 
       - name: Byte-compile the client
         run: eldev -dtT -p compile --warnings-as-errors


### PR DESCRIPTION
The Emacs CI jobs have been flaking with HTTP 429s at the `setup-emacs` step: it resolves nix-emacs-ci's HEAD on every run, and those unauthenticated GitHub API calls get rate-limited. Pinning the action to a release didn't help (it still does the HEAD fetch).

This drops nix-emacs-ci entirely and runs each job inside the prebuilt `silex/emacs:<version>-ci-eldev` image, which ships Emacs and Eldev ready to go - no setup step, no GitHub API calls, so the rate-limit failure mode is gone. The `GITHUB_TOKEN`/`NIX_CONFIG` workaround and the `max-parallel: 1` throttle go away with it.