### PR TITLE
Stop freezing Emacs during the reload workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [#92](https://github.com/clojure-emacs/sayid/pull/92): Stop freezing Emacs during the `!` reload workflow; the re-enable/clear now runs on the reload's completion callback instead of fixed `sleep-for` delays.
 * [#91](https://github.com/clojure-emacs/sayid/pull/91): Collapse the `query-*-with-modifier` commands into prefix-aware `f`/`i` in the sayid buffer (use a prefix arg to prompt for a modifier; the `F`/`I` keys are gone), and bind `r` to refresh the view.
 * [#91](https://github.com/clojure-emacs/sayid/pull/91): Generate the in-Emacs help buffers from the keymaps so they can't drift, and base the output buffers on `special-mode`.
 * [#86](https://github.com/clojure-emacs/sayid/pull/86): Fix a state leak in the traced-buffer outer-trace command, a crash when navigating to a numeric trace id, and a couple of messages that broke on a literal `%` in a path.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -369,17 +369,20 @@ Refreshes the traced-functions view afterwards."
 
 ;;;###autoload
 (defun sayid-load-enable-clear ()
-  "Workflow helper function.
-Disable traces, load buffer, enable traces, clear log."
+  "Reload the current buffer with a clean slate of traces.
+Disable all traces, reload the buffer, and once the reload finishes re-enable
+the traces and clear the log.  The work after the reload is chained on its
+completion callback, so Emacs is never blocked waiting."
   (interactive)
   (sayid-trace-disable-all)
-  (sleep-for 0.5)
-  (cider-load-buffer)
-  (sleep-for 0.5)
-  (sayid-trace-enable-all)
-  (sayid-clear-log))
+  (cider-load-buffer
+   (current-buffer)
+   (cider-load-file-handler
+    (current-buffer)
+    (lambda (_buffer)
+      (sayid-trace-enable-all)
+      (sayid-clear-log)))))
 
-;; make-symbol is a liar
 (defvar sayid-prop->font '(("int"     . sayid-int-face)
                            ("float"   . sayid-float-face)
                            ("string"  . sayid-string-face)


### PR DESCRIPTION
Last of the audit's deeper items. `sayid-load-enable-clear` (bound to `!`) disables traces, reloads the buffer, then re-enables and clears - and it bridged the async reload with two blocking `(sleep-for 0.5)` calls. That froze Emacs for ~1s and was racy (0.5s is just a guess).

It now chains the re-enable/clear on `cider-load-buffer`'s completion handler, so they run exactly when the reload finishes and nothing blocks.

(The other deeper item - trimming the whole-buffer payload sent on trace commands - I looked at and concluded it isn't worth doing: the server parses that source to resolve the symbol and unsaved buffers have no file to fall back to, so the cost is real correctness risk for a negligible gain on these user-initiated commands.)