### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## unreleased
+## [0.3.0] - 2026-06-29
 
 * [#92](https://github.com/clojure-emacs/sayid/pull/92): Stop freezing Emacs during the `!` reload workflow; the re-enable/clear now runs on the reload's completion callback instead of fixed `sleep-for` delays.
 * [#91](https://github.com/clojure-emacs/sayid/pull/91): Collapse the `query-*-with-modifier` commands into prefix-aware `f`/`i` in the sayid buffer (use a prefix arg to prompt for a modifier; the `F`/`I` keys are gone), and bind `r` to refresh the view.

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ provides a very flexible Sayid API. Its ops are documented in
 
 Add this to the dependencies in your project.clj or lein profiles.clj:
 
-    [mx.cider/sayid "0.2.0"]
+    [mx.cider/sayid "0.3.0"]
 
 To use the bundled nREPL middleware, you'll want to include Sayid as a
 plug-in. Here's an example of a bare-bones profiles.clj that works for
 me:
 
 ```clojure
-{:user {:plugins [[mx.cider/sayid "0.2.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.3.0"]]}}
 ```
 
 ### Clojure CLI - deps.edn
@@ -69,7 +69,7 @@ tools.deps config directory (often `$HOME/.clojure`).
 
 ```clojure
 {:deps
-  {mx.cider/sayid {:mvn/version "0.2.0"}}}
+  {mx.cider/sayid {:mvn/version "0.3.0"}}}
 ```
 
 ### Emacs Integration
@@ -94,7 +94,7 @@ that works for me:
 
 ```clojure
 {:user {:plugins [[cider/cider-nrepl "0.59.0"]
-                  [mx.cider/sayid "0.2.0"]]
+                  [mx.cider/sayid "0.3.0"]]
         :dependencies [[nrepl/nrepl "1.3.1"]]}}
 ```
 

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -11,7 +11,7 @@ This document is the reference for that wire API.
 With Leiningen, add Sayid as a plugin (it registers the middleware automatically):
 
 ```clojure
-{:user {:plugins [[mx.cider/sayid "0.2.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.3.0"]]}}
 ```
 
 Or add the middleware explicitly when you start the server, e.g. with the
@@ -211,7 +211,7 @@ Remove all traces and clear the recorded calls. Takes no params. Replies
 
 ### `sayid-version`
 
-Replies with the Sayid version string (e.g. `"0.2.0"`).
+Replies with the Sayid version string (e.g. `"0.3.0"`).
 
 ### `sayid-get-trace-count`
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mx.cider/sayid "0.2.0"
+(defproject mx.cider/sayid "0.3.0"
   :description "Sayid is a library for debugging and profiling clojure code."
   :url "https://github.com/clojure-emacs/sayid"
   :scm {:name "git" :url "https://github.com/clojure-emacs/sayid"}

--- a/src/com/billpiel/sayid/core.clj
+++ b/src/com/billpiel/sayid/core.clj
@@ -13,7 +13,7 @@
 
 (def version
   "The current version of sayid as a string."
-  "0.2.0")
+  "0.3.0")
 
 (def workspace
   "The active workspace. Used by default in any function prefixed `ws-`

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -4,7 +4,7 @@
 
 ;; Author: Bill Piel <bill@billpiel.com>
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
-;; Version: 0.2.0
+;; Version: 0.3.0
 ;; URL: https://github.com/clojure-emacs/sayid
 ;; Package-Requires: ((emacs "28") (cider "1.0"))
 ;; Keywords: clojure, cider, debugger
@@ -50,11 +50,11 @@ The injected dependencies are most likely nREPL middlewares."
   :type 'boolean)
 
 (defconst sayid-version
-  "0.2.0"
+  "0.3.0"
   "The current version of sayid.")
 
 (defconst sayid-injected-plugin-version
-  "0.2.0"
+  "0.3.0"
   "The version of the sayid Lein plugin to be automatically injected.")
 
 (defface sayid-int-face '((t :inherit default))

--- a/src/sayid/plugin.clj
+++ b/src/sayid/plugin.clj
@@ -2,7 +2,7 @@
 
 (def version
   "The current version of sayid as a string."
-  "0.2.0")
+  "0.3.0")
 
 (defn middleware
   [project]


### PR DESCRIPTION
Cuts 0.3.0. Bumps the version everywhere and converts the unreleased changelog into the 0.3.0 entry.

Since 0.2.0: a Buttercup test suite + reliable container-based Emacs CI, the bug fixes (#86), and the Emacs client cleanup/modernization (#89, #90, #91, #92) - generated help, `special-mode` buffers, prefix-aware query commands (`F`/`I` dropped, use `C-u f`/`C-u i`), and a non-blocking reload.

The Clojars publish (dual coordinates, per doc/releasing.md) is a separate manual step once this merges.