### PR TITLE
Drop the version suffixes from the core namespaces

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -27,19 +27,20 @@ that's the tie-breaker.
 
 | namespace | LOC | role |
 |-----------|-----|------|
-| `inner_trace3` | 857 | inner tracing by re-reading and rewriting source - fragile |
-| `string_output2` | 662 | rendering to text + text-property spans |
+| `inner-trace` | 857 | inner tracing by re-reading and rewriting source - fragile |
+| `string-output` | 662 | rendering to text + text-property spans |
 | `core` | 600 | public REPL API / engine hub |
 | `nrepl_middleware` | 549 | wire protocol, but also owns rendering |
-| `query2` | 471 | the query DSL |
+| `query` | 471 | the query DSL |
 | `util/other` | 402 | grab-bag utilities |
 | `trace` | 289 | outer tracing |
 | `workspace` / `recording` / `shelf` | 178 / 87 / 46 | the in-memory capture store |
 | `view` / `profiling` / `sayid_multifn` | 107 / 114 / 56 | views, profiling, AOT multimethod support |
 
-The `2`/`3` suffixes are a tell: these subsystems have been rewritten in place
-with the older strata left visible. The engine, the wire protocol, and the
-renderer are entangled, which is why there is exactly one client.
+The version-suffixed names (`query2`, `string_output2`, `inner_trace3`) have been
+de-versioned - that was the easy part. The deeper issue remains: the engine, the
+wire protocol, and the renderer are entangled, which is why there is exactly one
+client.
 
 ## Initiatives
 
@@ -56,14 +57,14 @@ gave the Emacs client this treatment recently; the Clojure core deserves the sam
 pass.
 
 **Approach:**
-- Inventory the public surface of `core` (what the README and middleware actually
-  call) and lock it with a `clojure.test` characterization suite before touching
-  anything. This is the safety net for all the moves below.
-- Rename `query2` -> `query`, `string_output2` -> `render` (or `output`),
-  `inner_trace3` -> `inner-trace`, with deprecated aliases for one release.
+- *Done.* Locked `core`'s public surface with a `clojure.test` characterization
+  suite before touching anything - the safety net for the moves below.
+- *Done.* Dropped the version suffixes: `query2` -> `query`, `string_output2` ->
+  `string-output`, `inner_trace3` -> `inner-trace`. No aliases; Sayid has no
+  external clients.
 - Draw a hard line between three layers and stop letting them reach across it:
   - **engine** - `trace`, `inner-trace`, `workspace`, `recording`, `shelf`
-  - **query/render** - `query`, `render`, `view`
+  - **query/render** - `query`, `string-output`, `view`
   - **protocol** - `nrepl_middleware` (which should call the engine and *return
     data*, see initiative 3).
 - Break up `util/other` (402 lines of grab-bag) into focused namespaces, deleting
@@ -132,9 +133,10 @@ navigate a workspace without any Sayid-specific rendering.
 **Goal:** inner tracing that doesn't detonate on missing source, reader
 conditionals, or the next macro nobody tested.
 
-**Why:** `inner_trace3` (the "3" says it all) re-reads the `.clj` from disk and
-rewrites raw forms, which is why it throws on `NO_SOURCE_FILE` and needed a fix
-just for `letfn`. It's the least trustworthy part of an otherwise solid tool.
+**Why:** `inner-trace` re-reads the `.clj` from disk and rewrites raw forms,
+which is why it throws on `NO_SOURCE_FILE` and needed a fix just for `letfn`. It's
+the least trustworthy part of an otherwise solid tool (and the `inner_trace3` it
+grew out of had been rewritten twice already).
 
 **Approach:**
 - Rebuild instrumentation on

--- a/src/com/billpiel/sayid/core.clj
+++ b/src/com/billpiel/sayid/core.clj
@@ -1,7 +1,7 @@
 (ns com.billpiel.sayid.core
   (:require clojure.pprint
             [com.billpiel.sayid.trace :as trace]
-            [com.billpiel.sayid.inner-trace3 :as itrace]
+            [com.billpiel.sayid.inner-trace :as itrace]
             [com.billpiel.sayid.workspace :as ws]
             [com.billpiel.sayid.recording :as rec]
             [com.billpiel.sayid.query :as q]

--- a/src/com/billpiel/sayid/core.clj
+++ b/src/com/billpiel/sayid/core.clj
@@ -4,7 +4,7 @@
             [com.billpiel.sayid.inner-trace3 :as itrace]
             [com.billpiel.sayid.workspace :as ws]
             [com.billpiel.sayid.recording :as rec]
-            [com.billpiel.sayid.query2 :as q]
+            [com.billpiel.sayid.query :as q]
             [com.billpiel.sayid.view :as v]
             [com.billpiel.sayid.util.find-ns :as find-ns]
             [com.billpiel.sayid.string-output2 :as so]

--- a/src/com/billpiel/sayid/core.clj
+++ b/src/com/billpiel/sayid/core.clj
@@ -7,7 +7,7 @@
             [com.billpiel.sayid.query :as q]
             [com.billpiel.sayid.view :as v]
             [com.billpiel.sayid.util.find-ns :as find-ns]
-            [com.billpiel.sayid.string-output2 :as so]
+            [com.billpiel.sayid.string-output :as so]
             [com.billpiel.sayid.profiling :as pro]
             [com.billpiel.sayid.util.other :as util]))
 

--- a/src/com/billpiel/sayid/inner_trace.clj
+++ b/src/com/billpiel/sayid/inner_trace.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.inner-trace3
+(ns com.billpiel.sayid.inner-trace
   (:require [com.billpiel.sayid.util.other :as util :refer [$-]]
             [com.billpiel.sayid.trace :as trace]
             clojure.pprint
@@ -834,24 +834,24 @@
     (inc a)
     (inc a)))
 
-#_ (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace3/f1
-                  :meta' {:ns 'com.billpiel.sayid.inner-trace3
-                          :name 'com.billpiel.sayid.inner-trace3/f1}
-                 :ns' 'com.billpiel.sayid.inner-trace3})
+#_ (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace/f1
+                  :meta' {:ns 'com.billpiel.sayid.inner-trace
+                          :name 'com.billpiel.sayid.inner-trace/f1}
+                 :ns' 'com.billpiel.sayid.inner-trace})
 
 #_ (binding [trace/*trace-log-parent* {:id :root1 :children (atom [])}]
-     (let [f1 (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace3/f1
-                            :meta' {:ns 'com.billpiel.sayid.inner-trace3
-                          :name 'com.billpiel.sayid.inner-trace3/f1}
-                            :ns' 'com.billpiel.sayid.inner-trace3})]
+     (let [f1 (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace/f1
+                            :meta' {:ns 'com.billpiel.sayid.inner-trace
+                          :name 'com.billpiel.sayid.inner-trace/f1}
+                            :ns' 'com.billpiel.sayid.inner-trace})]
        (f1 2)
        (clojure.pprint/pprint trace/*trace-log-parent*)))
 
 #_ (binding [trace/*trace-log-parent* @com.billpiel.sayid.core/workspace]
-     (let [f1 (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace3/f1
-                             :meta' {:ns 'com.billpiel.sayid.inner-trace3
-                                     :name 'com.billpiel.sayid.inner-trace3/f1}
-                             :ns' 'com.billpiel.sayid.inner-trace3})]
+     (let [f1 (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace/f1
+                             :meta' {:ns 'com.billpiel.sayid.inner-trace
+                                     :name 'com.billpiel.sayid.inner-trace/f1}
+                             :ns' 'com.billpiel.sayid.inner-trace})]
        (f1 0)
 #_       (clojure.pprint/pprint trace/*trace-log-parent*)))
 

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -7,7 +7,7 @@
    [clojure.tools.reader :as r]
    [clojure.tools.reader.reader-types :as rts]
    [com.billpiel.sayid.core :as sd]
-   [com.billpiel.sayid.query2 :as q]
+   [com.billpiel.sayid.query :as q]
    [com.billpiel.sayid.string-output2 :as so]
    [com.billpiel.sayid.trace :as tr]
    [com.billpiel.sayid.util.find-ns :as find-ns]

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -8,7 +8,7 @@
    [clojure.tools.reader.reader-types :as rts]
    [com.billpiel.sayid.core :as sd]
    [com.billpiel.sayid.query :as q]
-   [com.billpiel.sayid.string-output2 :as so]
+   [com.billpiel.sayid.string-output :as so]
    [com.billpiel.sayid.trace :as tr]
    [com.billpiel.sayid.util.find-ns :as find-ns]
    [com.billpiel.sayid.util.other :as util]

--- a/src/com/billpiel/sayid/query.clj
+++ b/src/com/billpiel/sayid/query.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.query2
+(ns com.billpiel.sayid.query
   (:require [clojure.zip :as z]
             clojure.set
             clojure.string

--- a/src/com/billpiel/sayid/string_output.clj
+++ b/src/com/billpiel/sayid/string_output.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.string-output2
+(ns com.billpiel.sayid.string-output
   (:require [com.billpiel.sayid.workspace :as ws]
             [com.billpiel.sayid.view :as v]
             [com.billpiel.sayid.util.other :as util]

--- a/test/com/billpiel/sayid/core_test.clj
+++ b/test/com/billpiel/sayid/core_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :as t]
             [com.billpiel.sayid.core :as sd]
             [com.billpiel.sayid.trace :as sdt]
-            [com.billpiel.sayid.query2 :as sdq]
+            [com.billpiel.sayid.query :as sdq]
             [com.billpiel.sayid.test-utils :as t-utils]
             [com.billpiel.sayid.test-ns1 :as ns1]
             [com.billpiel.sayid.string-output2 :as sds]))

--- a/test/com/billpiel/sayid/core_test.clj
+++ b/test/com/billpiel/sayid/core_test.clj
@@ -5,7 +5,7 @@
             [com.billpiel.sayid.query :as sdq]
             [com.billpiel.sayid.test-utils :as t-utils]
             [com.billpiel.sayid.test-ns1 :as ns1]
-            [com.billpiel.sayid.string-output2 :as sds]))
+            [com.billpiel.sayid.string-output :as sds]))
 
 
 (defn- fixture

--- a/test/com/billpiel/sayid/public_api_test.clj
+++ b/test/com/billpiel/sayid/public_api_test.clj
@@ -6,7 +6,7 @@
   and `workspace-test`.  This namespace adds the pieces that refactor needs
   most and that were missing: a guard on the public API surface itself, and
   characterizations of rendering and profiling - two public paths the refactor
-  touches (`string-output2`, `profiling`) that had no coverage."
+  touches (`string-output`, `profiling`) that had no coverage."
   (:require [clojure.test :as t]
             [clojure.string :as str]
             [com.billpiel.sayid.core :as sd]
@@ -51,7 +51,7 @@
       (t/is (some? (ns-resolve 'com.billpiel.sayid.core sym))
             (str sym " must remain part of core's public API")))))
 
-;;; --- Rendering (string-output2) ---------------------------------------------
+;;; --- Rendering (string-output) ---------------------------------------------
 
 (defn- strip-ansi
   [s]

--- a/test/com/billpiel/sayid/query_test.clj
+++ b/test/com/billpiel/sayid/query_test.clj
@@ -1,7 +1,7 @@
 (ns com.billpiel.sayid.query-test
   (:require [clojure.test :as t]
             [com.billpiel.sayid.core :as sd]
-            [com.billpiel.sayid.query2 :as q]
+            [com.billpiel.sayid.query :as q]
             [com.billpiel.sayid.test-utils :as t-utils]))
 
 (comment "


### PR DESCRIPTION
First mechanical step of the roadmap's core cleanup (initiative 1), now that the characterization safety net is in place.

Renames, each its own commit, with all requires updated in place and no aliases (Sayid has no external clients):

- `com.billpiel.sayid.query2` -> `query`
- `com.billpiel.sayid.string-output2` -> `string-output`
- `com.billpiel.sayid.inner-trace3` -> `inner-trace`

Plus a commit syncing `doc/roadmap.md` with the completed work. Pure rename - no behavior change; the full suite (32 tests, 93 assertions) and kondo stay green, and the new public-surface guard confirms `core`'s API is intact.