### PR TITLE
Clean up and break up util/other

### DIFF
--- a/src/com/billpiel/sayid/core.clj
+++ b/src/com/billpiel/sayid/core.clj
@@ -9,7 +9,8 @@
             [com.billpiel.sayid.util.find-ns :as find-ns]
             [com.billpiel.sayid.string-output :as so]
             [com.billpiel.sayid.profiling :as pro]
-            [com.billpiel.sayid.util.other :as util]))
+            [com.billpiel.sayid.util.other :as util]
+            [com.billpiel.sayid.util.sym :as sym]))
 
 (def version
   "The current version of sayid as a string."
@@ -124,7 +125,7 @@ user> (-> #'f1 meta :source)
   enabled trace to said functions. Adds the traces to the active
   workspace trace set."
   [fn-sym]
-  `(ws-add-trace-fn!* (util/fully-qualify-sym '~fn-sym)))
+  `(ws-add-trace-fn!* (sym/fully-qualify-sym '~fn-sym)))
 (util/defalias-macro w-atf! ws-add-trace-fn!)
 
 (defn ^:no-doc ws-add-inner-trace-fn!*
@@ -140,7 +141,7 @@ user> (-> #'f1 meta :source)
   workspace trace set. Deep traces capture all functions calls that
   occurr within the traced function."
   [fn-sym]
-  `(ws-add-inner-trace-fn!* (util/fully-qualify-sym ~(util/quote-if-sym fn-sym))))
+  `(ws-add-inner-trace-fn!* (sym/fully-qualify-sym ~(util/quote-if-sym fn-sym))))
 
 (util/defalias-macro w-aitf! ws-add-inner-trace-fn!)
 
@@ -197,7 +198,7 @@ user> (-> #'f1 meta :source)
   [ns-sym] (#'ws/disable-all-traces! workspace
                                      #(or (= % ns-sym)
                                           (-> %
-                                              util/disqualify-sym
+                                              sym/disqualify-sym
                                               first
                                               (= ns-sym)))))
 
@@ -483,7 +484,7 @@ user> (-> #'f1 meta :source)
   "Produces a vector like [:name 'func] for `s` equal to 'func. Just a
   little shortcut for when querying by a function name."
   [s]
-  `[:name '~(util/fully-qualify-sym s)])
+  `[:name '~(sym/fully-qualify-sym s)])
 (util/defalias-macro qbn query-by-name)
 
 (defn- syms->qbn

--- a/src/com/billpiel/sayid/inner_trace.clj
+++ b/src/com/billpiel/sayid/inner_trace.clj
@@ -1,5 +1,7 @@
 (ns com.billpiel.sayid.inner-trace
   (:require [com.billpiel.sayid.util.other :as util :refer [$-]]
+            [com.billpiel.sayid.util.sym :as sym]
+            [com.billpiel.sayid.util.source :as src]
             [com.billpiel.sayid.trace :as trace]
             clojure.pprint
             clojure.set
@@ -9,8 +11,8 @@
 (defn form->xform-map*
   [ns-sym form]
   (if (coll? form)
-    (let [x (util/macroexpand-in-ns ns-sym form)
-          xx (util/macroexpand-all-in-ns ns-sym form)]
+    (let [x (sym/macroexpand-in-ns ns-sym form)
+          xx (sym/macroexpand-all-in-ns ns-sym form)]
       (conj (mapcat (partial form->xform-map*
                              ns-sym)
                     x)
@@ -31,7 +33,7 @@
   [ns-sym form func parent path skip-macro?]
   (cond
     (and skip-macro?
-         (util/macro? ns-sym form)) form
+         (sym/macro? ns-sym form)) form
     (coll? form)  (util/back-into form
                                   (doall (map-indexed #(swap-in-path-syms* ns-sym
                                                                            %2
@@ -120,30 +122,30 @@
 (defn mk-expr-mapping
   [ns-sym form]
   (let [xls (->> form
-                 (util/macroexpand-all-in-ns ns-sym)
+                 (sym/macroexpand-all-in-ns ns-sym)
                  (swap-in-path-syms ns-sym)
                  (tree-seq coll? seq))
-        xloc->oloc (util/deep-zipmap (->> form (util/macroexpand-all-in-ns ns-sym) (swap-in-path-syms ns-sym))
-                                     (->> form (swap-in-path-syms-skip-macro ns-sym) (util/macroexpand-all-in-ns ns-sym)))
+        xloc->oloc (util/deep-zipmap (->> form (sym/macroexpand-all-in-ns ns-sym) (swap-in-path-syms ns-sym))
+                                     (->> form (swap-in-path-syms-skip-macro ns-sym) (sym/macroexpand-all-in-ns ns-sym)))
         oloc->xloc (clojure.set/map-invert xloc->oloc)
-        xl->xform  (util/deep-zipmap (->> form (util/macroexpand-all-in-ns ns-sym) (swap-in-path-syms ns-sym))
-                                     (util/macroexpand-all-in-ns ns-sym form))
+        xl->xform  (util/deep-zipmap (->> form (sym/macroexpand-all-in-ns ns-sym) (swap-in-path-syms ns-sym))
+                                     (sym/macroexpand-all-in-ns ns-sym form))
         xform->form (xform->form-map ns-sym form)
         ol->olop (->> form
                       (swap-in-path-syms ns-sym)
                       get-path->form-maps)
         xl->xlxp (->> form
-                      (util/macroexpand-all-in-ns ns-sym)
+                      (sym/macroexpand-all-in-ns ns-sym)
                       (swap-in-path-syms ns-sym)
                       get-path->form-maps)
         ol->olxp (->> form
                       (swap-in-path-syms ns-sym)
-                      (util/macroexpand-all-in-ns ns-sym)
+                      (sym/macroexpand-all-in-ns ns-sym)
                       get-path->form-maps)
         xlxp->xp (util/deep-zipmap (->> form
-                                        (util/macroexpand-all-in-ns ns-sym)
+                                        (sym/macroexpand-all-in-ns ns-sym)
                                         (swap-in-path-syms ns-sym))
-                                   (util/macroexpand-all-in-ns ns-sym form))
+                                   (sym/macroexpand-all-in-ns ns-sym form))
         olop->op (util/deep-zipmap (swap-in-path-syms ns-sym form) form)
         f (fn [xl]
             (when-let [xl' (if (coll? xl)
@@ -490,7 +492,7 @@
 
 (defn xpand-macro
   [head form src-map fn-meta path path-parent]
-  (let [xform (with-meta-safe (util/macroexpand-in-ns (:ns-sym fn-meta)
+  (let [xform (with-meta-safe (sym/macroexpand-in-ns (:ns-sym fn-meta)
                                                       form)
                 (meta form))] ;; TODO be sure this is doing something
     (let [path' (conj path :macro)
@@ -714,7 +716,7 @@
           (= 'loop head) (apply xpand-loop args)
           (= 'recur head) (apply xpand-recur args)
           (= 'if head) (apply xpand-if args)
-          (util/macro? (:ns-sym fn-meta) head) (apply xpand-macro head args)
+          (sym/macro? (:ns-sym fn-meta) head) (apply xpand-macro head args)
           (or (special-symbol? head)
               (dot-sym? head)) ;; TODO better way to detect these?
           (apply xpand-all args)
@@ -794,13 +796,13 @@
         meta'' (assoc meta' :ns-sym ns-sym)
         src (-> qual-sym
                 symbol
-                util/hunt-down-source)
+                src/hunt-down-source)
         traced-form ($- ->
                         src
-                        (util/macroexpand-in-ns ns-sym $)
+                        (sym/macroexpand-in-ns ns-sym $)
                         get-fn
                         (xpand-fn* meta''))]
-    (try (util/eval-in-ns (-> ns' str symbol)
+    (try (sym/eval-in-ns (-> ns' str symbol)
                           traced-form)
          (catch Exception e
            (clojure.pprint/pprint traced-form)

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -12,6 +12,7 @@
    [com.billpiel.sayid.trace :as tr]
    [com.billpiel.sayid.util.find-ns :as find-ns]
    [com.billpiel.sayid.util.other :as util]
+   [com.billpiel.sayid.util.sym :as sym]
    [com.billpiel.sayid.view :as v]
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.misc :refer [response-for]]
@@ -171,7 +172,7 @@ or nil when nothing resolves there."
   [{:keys [action file line column source] :as msg}]
   (let [sym (get-sym-at-pos-in-source file line column source)
         ns-sym (symbol (parse-ns-name-from-source source))
-        qual-sym (util/resolve-to-qual-sym ns-sym sym)]
+        qual-sym (sym/resolve-to-qual-sym ns-sym sym)]
     (when qual-sym
       ((fn-trace-actions action) qual-sym))
     (reply:clj->nrepl msg qual-sym)))
@@ -286,7 +287,7 @@ or nil when nothing resolves there."
 (defn ^:nrepl sayid-trace-fn
   "Apply trace ACTION to the function named by MSG's fn-ns/fn-name."
   [{:keys [action fn-name fn-ns] :as msg}]
-  ((fn-trace-actions action) (util/qualify-sym fn-ns fn-name))
+  ((fn-trace-actions action) (sym/qualify-sym fn-ns fn-name))
   (send-status-done msg))
 
 ;; `ws-remove-trace-ns!' is a macro that captures its argument's literal form,
@@ -406,7 +407,7 @@ or nil when nothing resolves there."
     (doseq [pair (map vector
                       arglist-template-seq
                       (:args tree))]
-      (apply util/def-ns-var
+      (apply sym/def-ns-var
              '$s
              pair))
     (format "(%s%s)"
@@ -430,7 +431,7 @@ or nil when nothing resolves there."
 (defn ^:nrepl sayid-def-value
   [{:keys [transport trace-id path] :as msg}]
   (let [path' (str-vec->arg-path path)]
-    (util/def-ns-var '$s '* (-> [:id (keyword trace-id)]
+    (sym/def-ns-var '$s '* (-> [:id (keyword trace-id)]
                                 sd/ws-query*
                                 :children
                                 first

--- a/src/com/billpiel/sayid/shelf.clj
+++ b/src/com/billpiel/sayid/shelf.clj
@@ -1,5 +1,6 @@
 (ns com.billpiel.sayid.shelf
-  (:require [com.billpiel.sayid.util.other :as util]))
+  (:require [com.billpiel.sayid.util.other :as util]
+            [com.billpiel.sayid.util.sym :as sym]))
 
 
 (defn save!
@@ -7,7 +8,7 @@
   (let [item' @item
         slot (slot-kw item')]
     (if (symbol? slot)
-      (util/def-ns-var shelf slot item')
+      (sym/def-ns-var shelf slot item')
       (throw (Exception. ^String (mk-ex-msg-fn
                                   slot))))
     item'))
@@ -16,7 +17,7 @@
   [item shelf slot-kw slot mk-ex-msg-fn]
   (doto item
     (swap! assoc slot-kw
-           (util/qualify-sym shelf slot))
+           (sym/qualify-sym shelf slot))
     (save! shelf slot-kw mk-ex-msg-fn)))
 
 (defn safe-to-load?

--- a/src/com/billpiel/sayid/string_output.clj
+++ b/src/com/billpiel/sayid/string_output.clj
@@ -2,6 +2,7 @@
   (:require [com.billpiel.sayid.workspace :as ws]
             [com.billpiel.sayid.view :as v]
             [com.billpiel.sayid.util.other :as util]
+            [com.billpiel.sayid.util.source :as src]
             [tamarin.core :as tam]
             [clojure.zip :as z]
             clojure.set
@@ -137,7 +138,7 @@
                   :path path
                   :header header?)
            (update-in [:file] #(if (string? %)
-                                 (util/get-src-file-path %)
+                                 (src/get-src-file-path %)
                                  %))
            (assoc $
                   :line-meta? true)))

--- a/src/com/billpiel/sayid/trace.clj
+++ b/src/com/billpiel/sayid/trace.clj
@@ -1,5 +1,6 @@
 (ns com.billpiel.sayid.trace
-  (:require [com.billpiel.sayid.util.other :as util])
+  (:require [com.billpiel.sayid.util.other :as util]
+            [com.billpiel.sayid.util.sym :as sym])
   (:import com.billpiel.sayid.SayidMultiFn))
 
 (def ^:dynamic *trace-log-parent* nil)
@@ -137,7 +138,7 @@
         s  (.sym v)
         m (meta v)
         f @v
-        vname (util/qualify-sym ns s )]
+        vname (sym/qualify-sym ns s )]
     (doto v
       (alter-var-root (partial tracer-fn
                                {:workspace workspace

--- a/src/com/billpiel/sayid/util/other.clj
+++ b/src/com/billpiel/sayid/util/other.clj
@@ -88,8 +88,6 @@
 
 (defn arg-match
   [arglists args]
-  (def arglists' arglists)
-  (def args' args)
   (if (not-empty arglists)
     (let [args-v (vec args)
           matcher-fn (->> arglists
@@ -143,19 +141,6 @@
     @maybe-atom
     maybe-atom))
 
-(defn atom?-fn
-  [maybe-atom]
-  (if (atom? maybe-atom)
-    [@maybe-atom
-     (fn [newval]
-       (reset! maybe-atom newval)
-       maybe-atom)
-     (fn [f]
-       (swap! maybe-atom f)
-       maybe-atom)]
-    [maybe-atom identity identity]))
-
-
 (defn derefable?
   [v]
   (instance? clojure.lang.IDeref v))
@@ -182,8 +167,6 @@
                   (and t-fn (not f)) (constantly obj)
                   :else (constantly f))]
         (fn' obj)))))
-
-(def opae obj-pred-action-else)
 
 (defn just-get-whatever-you-can
   [ns-sym clue]
@@ -256,25 +239,6 @@
   [alias source]
   (defalias-macro* alias source))
 
-(defn ns-unmap-all
-  [ns']
-  (->> ns'
-       ns-map
-       keys
-       (map (partial ns-unmap ns'))
-       dorun))
-
-(defn source-fn-var
-  [fn-var]
-  (->> fn-var
-       meta
-       ((juxt :ns
-              (constantly "/")
-              :name))
-       (apply str)
-       symbol
-       clojure.repl/source-fn))
-
 (defn mk-dummy-whitespace
   [lines cols]
   (apply str
@@ -321,12 +285,6 @@
    (into (or (empty orig)
              [])
          noob)))
-
-(defn deep-zipmap-no-colls
-       [a b]
-       (zipmap (filter (comp not coll?) (tree-seq coll? seq a))
-               (filter (comp not coll?) (tree-seq coll? seq b))))
-
 
 (defn deep-zipmap
        [a b]
@@ -379,14 +337,6 @@
   (if (symbol? v)
     `'~v
     v))
-
-(defn first-match
-  [pred coll]
-  (let [[head & tail] coll]
-    (cond (nil? coll) nil
-          (empty? coll) nil
-          (pred head) head
-          :else (recur pred tail))))
 
 (defn get-src-file-path
   [s]

--- a/src/com/billpiel/sayid/util/other.clj
+++ b/src/com/billpiel/sayid/util/other.clj
@@ -1,10 +1,8 @@
 (ns com.billpiel.sayid.util.other
+  "General-purpose helpers that don't have a more specific home.  Symbol and
+  namespace helpers live in `util.sym`, source-reading in `util.source`."
   (:require [clojure.walk :as walk]
-            clojure.java.io
-            [clojure.tools.reader :as r]
-            [clojure.tools.reader.reader-types :as rts]
-            clojure.repl
-            clojure.string))
+            [com.billpiel.sayid.util.sym :as sym]))
 
 (defn ->int
   [v]
@@ -27,33 +25,6 @@
         (keyword? v) (-> v name symbol)
         (string? v) (symbol v)
         :else (-> v str symbol)))
-
-(defn def-ns-var
-  [ws-ns-sym sym v]
-  (binding [*ns* (create-ns ws-ns-sym)]
-    (eval `(def ~sym '~v))))
-
-(defn eval-in-ns
-  [ns-sym form]
-  (binding [*ns* (create-ns ns-sym)]
-    (use 'clojure.core)
-    (eval form)))
-
-(defn macroexpand-in-ns
-  [ns-sym form]
-  (eval-in-ns ns-sym `(macroexpand '~form)))
-
-(defn macroexpand-all-in-ns
-  [ns-sym form]
-  (eval-in-ns ns-sym `(walk/macroexpand-all '~form)))
-
-(defn macro?
-  [ns-sym m-sym]
-  (try (some->> m-sym
-                (ns-resolve ns-sym)
-                meta
-                :macro)
-       (catch Exception e false)))
 
 (defmacro get-env
   []
@@ -102,34 +73,6 @@
     (arg-match arglists args)
     (catch Exception e
       nil)))
-
-(defn qualify-sym
-  [ns sym]
-  (symbol (str ns)
-          (str sym)))
-
-(defn disqualify-sym
-  [fn-sym]
-  (->> fn-sym
-       str
-       (re-find #"(.*?)/(.*)")
-       rest
-       (mapv symbol)))
-
-(defmacro fully-qualify-sym
-  [sym]
-  `(let [m# (-> ~sym
-                resolve
-                meta)
-         ns# (-> m# :ns str)
-         name# (-> m# :name)]
-     (qualify-sym ns# name#)))
-
-(defn resolve-to-qual-sym [ns-sym sym]
-  (try (when-let [{:keys [name ns]} (meta (ns-resolve ns-sym sym))]
-         (qualify-sym ns name))
-       (catch Exception e
-         nil)))
 
 (defn atom?
   [v]
@@ -204,7 +147,7 @@
 (defn defalias-macro*
   [alias source]
   (let [body-sym (gensym "body")
-        qualified-source (qualify-sym *ns* source)
+        qualified-source (sym/qualify-sym *ns* source)
         source-meta (->> source
                          (ns-resolve *ns*)
                          meta)
@@ -238,39 +181,6 @@
 (defmacro defalias-macro
   [alias source]
   (defalias-macro* alias source))
-
-(defn mk-dummy-whitespace
-  [lines cols]
-  (apply str
-         (concat (repeat lines "\n")
-                 (repeat cols " "))))
-
-(defn mk-positionalble-src-logging-push-back-rdr
-  [s file line col]
-  (rts/source-logging-push-back-reader (str (mk-dummy-whitespace (dec line) ;;this seem unfortunate
-                                                                 (dec col))
-                                            s)
-                                       (+ (count s) line col 1)
-                                       file))
-
-(defn hunt-down-source
-  [fn-sym]
-  (let [{:keys [source file line column]} (-> fn-sym
-                                              resolve
-                                              meta)]
-    (or source
-        (r/read (mk-positionalble-src-logging-push-back-rdr
-                 (or
-                  (clojure.repl/source-fn fn-sym)
-                  (->> file
-                       slurp
-                       clojure.string/split-lines
-                       (drop (dec line))
-                       (clojure.string/join "\n"))
-                  "nil")
-                 file
-                 line
-                 column)))))
 
 (defmacro src-in-meta
   [& body]
@@ -337,14 +247,6 @@
   (if (symbol? v)
     `'~v
     v))
-
-(defn get-src-file-path
-  [s]
-  (let [s' (clojure.string/replace s #"^file:" "")]
-    (if (.exists (java.io.File. s'))
-      s'
-      (when-let [r (clojure.java.io/resource s')]
-        (.getPath r)))))
 
 (defn fn*?
   [maybe]

--- a/src/com/billpiel/sayid/util/source.clj
+++ b/src/com/billpiel/sayid/util/source.clj
@@ -1,0 +1,49 @@
+(ns com.billpiel.sayid.util.source
+  "Helpers for locating and reading the source of a function, used by inner
+  tracing to recover the form it needs to instrument."
+  (:require [clojure.tools.reader :as r]
+            [clojure.tools.reader.reader-types :as rts]
+            clojure.repl
+            clojure.string
+            clojure.java.io))
+
+(defn mk-dummy-whitespace
+  [lines cols]
+  (apply str
+         (concat (repeat lines "\n")
+                 (repeat cols " "))))
+
+(defn mk-positionalble-src-logging-push-back-rdr
+  [s file line col]
+  (rts/source-logging-push-back-reader (str (mk-dummy-whitespace (dec line) ;;this seem unfortunate
+                                                                 (dec col))
+                                            s)
+                                       (+ (count s) line col 1)
+                                       file))
+
+(defn hunt-down-source
+  [fn-sym]
+  (let [{:keys [source file line column]} (-> fn-sym
+                                              resolve
+                                              meta)]
+    (or source
+        (r/read (mk-positionalble-src-logging-push-back-rdr
+                 (or
+                  (clojure.repl/source-fn fn-sym)
+                  (->> file
+                       slurp
+                       clojure.string/split-lines
+                       (drop (dec line))
+                       (clojure.string/join "\n"))
+                  "nil")
+                 file
+                 line
+                 column)))))
+
+(defn get-src-file-path
+  [s]
+  (let [s' (clojure.string/replace s #"^file:" "")]
+    (if (.exists (java.io.File. s'))
+      s'
+      (when-let [r (clojure.java.io/resource s')]
+        (.getPath r)))))

--- a/src/com/billpiel/sayid/util/sym.clj
+++ b/src/com/billpiel/sayid/util/sym.clj
@@ -1,0 +1,59 @@
+(ns com.billpiel.sayid.util.sym
+  "Helpers for working with symbols and namespaces: qualifying and resolving
+  symbols, and evaluating or macroexpanding forms in a given namespace."
+  (:require [clojure.walk :as walk]))
+
+(defn def-ns-var
+  [ws-ns-sym sym v]
+  (binding [*ns* (create-ns ws-ns-sym)]
+    (eval `(def ~sym '~v))))
+
+(defn eval-in-ns
+  [ns-sym form]
+  (binding [*ns* (create-ns ns-sym)]
+    (use 'clojure.core)
+    (eval form)))
+
+(defn macroexpand-in-ns
+  [ns-sym form]
+  (eval-in-ns ns-sym `(macroexpand '~form)))
+
+(defn macroexpand-all-in-ns
+  [ns-sym form]
+  (eval-in-ns ns-sym `(walk/macroexpand-all '~form)))
+
+(defn macro?
+  [ns-sym m-sym]
+  (try (some->> m-sym
+                (ns-resolve ns-sym)
+                meta
+                :macro)
+       (catch Exception e false)))
+
+(defn qualify-sym
+  [ns sym]
+  (symbol (str ns)
+          (str sym)))
+
+(defn disqualify-sym
+  [fn-sym]
+  (->> fn-sym
+       str
+       (re-find #"(.*?)/(.*)")
+       rest
+       (mapv symbol)))
+
+(defmacro fully-qualify-sym
+  [sym]
+  `(let [m# (-> ~sym
+                resolve
+                meta)
+         ns# (-> m# :ns str)
+         name# (-> m# :name)]
+     (qualify-sym ns# name#)))
+
+(defn resolve-to-qual-sym [ns-sym sym]
+  (try (when-let [{:keys [name ns]} (meta (ns-resolve ns-sym sym))]
+         (qualify-sym ns name))
+       (catch Exception e
+         nil)))

--- a/src/com/billpiel/sayid/workspace.clj
+++ b/src/com/billpiel/sayid/workspace.clj
@@ -1,6 +1,7 @@
 (ns com.billpiel.sayid.workspace
   (:require [com.billpiel.sayid.trace :as trace]
             [com.billpiel.sayid.util.other :as util]
+            [com.billpiel.sayid.util.sym :as sym]
             [com.billpiel.sayid.shelf :as shelf]))
 
 (def default-traced {:ns #{}
@@ -28,7 +29,7 @@
 
 (defn lookup-traces-by-fn
   [ws fn-sym]
-  (let [[ns-sym] (util/disqualify-sym fn-sym)]
+  (let [[ns-sym] (sym/disqualify-sym fn-sym)]
     (->> ws
          :traced
          (filter #(some (or (-> % second)


### PR DESCRIPTION
More of initiative 1's core cleanup. `util/other` was a 400-line grab-bag; this trims it to general data helpers.

Two commits:

- Delete six functions with no callers anywhere, plus two stray `(def ...)` debug forms inside `arg-match` that leaked top-level vars on every call.
- Extract the two most cohesive clusters into focused namespaces: `util.sym` (symbol/namespace resolution and in-ns eval/macroexpand) and `util.source` (locating and reading a function's source for inner tracing). This also moves the heavy tools.reader/clojure.repl/java.io deps off `util/other`.

`util/other` goes 403 -> 254 lines. Pure deletions and moves, no behaviour change; the full suite (32 tests, 93 assertions) and clj-kondo stay green.