### PR TITLE
Untangle the render layer from the engine

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -62,13 +62,20 @@ pass.
 - *Done.* Dropped the version suffixes: `query2` -> `query`, `string_output2` ->
   `string-output`, `inner_trace3` -> `inner-trace`. No aliases; Sayid has no
   external clients.
+- *Done.* Broke up `util/other`: deleted the dead code and split the
+  symbol/namespace and source-reading helpers into `util.sym` and `util.source`.
 - Draw a hard line between three layers and stop letting them reach across it:
   - **engine** - `trace`, `inner-trace`, `workspace`, `recording`, `shelf`
   - **query/render** - `query`, `string-output`, `view`
   - **protocol** - `nrepl_middleware` (which should call the engine and *return
     data*, see initiative 3).
-- Break up `util/other` (402 lines of grab-bag) into focused namespaces, deleting
-  what's dead.
+
+  Mostly there already: the engine has no upward deps, and once the stray unused
+  require and a dead scratch block were removed, `query`/`view`/`string-output`
+  stopped reaching into the engine too. The one real breach left is the protocol
+  owning rendering - the middleware calls `string-output` to build text-property
+  pairs for Emacs. Closing that *is* initiative 3 (return data, not strings), so
+  the hard line gets finished there.
 
 **Risks:** `sayid_multifn` is AOT-compiled and the namespace names are part of the
 deployed contract; renames need deprecated forwarders. Inner-trace rewriting reads

--- a/src/com/billpiel/sayid/inner_trace.clj
+++ b/src/com/billpiel/sayid/inner_trace.clj
@@ -829,31 +829,3 @@
       resolve
       trace/untrace-var*))
 
-
-(defn f1
-  [a]
-  (loop [a 1]
-    (inc a)
-    (inc a)))
-
-#_ (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace/f1
-                  :meta' {:ns 'com.billpiel.sayid.inner-trace
-                          :name 'com.billpiel.sayid.inner-trace/f1}
-                 :ns' 'com.billpiel.sayid.inner-trace})
-
-#_ (binding [trace/*trace-log-parent* {:id :root1 :children (atom [])}]
-     (let [f1 (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace/f1
-                            :meta' {:ns 'com.billpiel.sayid.inner-trace
-                          :name 'com.billpiel.sayid.inner-trace/f1}
-                            :ns' 'com.billpiel.sayid.inner-trace})]
-       (f1 2)
-       (clojure.pprint/pprint trace/*trace-log-parent*)))
-
-#_ (binding [trace/*trace-log-parent* @com.billpiel.sayid.core/workspace]
-     (let [f1 (inner-tracer {:qual-sym 'com.billpiel.sayid.inner-trace/f1
-                             :meta' {:ns 'com.billpiel.sayid.inner-trace
-                                     :name 'com.billpiel.sayid.inner-trace/f1}
-                             :ns' 'com.billpiel.sayid.inner-trace})]
-       (f1 0)
-#_       (clojure.pprint/pprint trace/*trace-log-parent*)))
-

--- a/src/com/billpiel/sayid/string_output.clj
+++ b/src/com/billpiel/sayid/string_output.clj
@@ -1,6 +1,5 @@
 (ns com.billpiel.sayid.string-output
-  (:require [com.billpiel.sayid.workspace :as ws]
-            [com.billpiel.sayid.view :as v]
+  (:require [com.billpiel.sayid.view :as v]
             [com.billpiel.sayid.util.other :as util]
             [com.billpiel.sayid.util.source :as src]
             [tamarin.core :as tam]


### PR DESCRIPTION
Continuing initiative 1. Mapping the require graph showed the layering is in better shape than the roadmap assumed - the engine has no upward dependencies once two dead edges are removed:

- `string-output` required `workspace` but never used it. Dropping it means the query/render layer no longer reaches into the engine.
- `inner-trace` ended with a throwaway `f1` fixture and three `#_`-discarded REPL snippets, one of which held the engine's only (dead) reference to `core`.

With those gone, the one structural breach left is the protocol owning rendering (the middleware builds text-property pairs via `string-output`), which is initiative 3's job. The roadmap is updated to say so. No behaviour change; suite and clj-kondo green.