### PR TITLE
Add a data-returning workspace op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* [#100](https://github.com/clojure-emacs/sayid/pull/100): Add the `sayid-get-workspace-data` nREPL op, which returns the recorded call tree as data (see [doc/nrepl-api.md](doc/nrepl-api.md)) for editor-agnostic clients.
+
 ## [0.3.0] - 2026-06-29
 
 * [#92](https://github.com/clojure-emacs/sayid/pull/92): Stop freezing Emacs during the `!` reload workflow; the re-enable/clear now runs on the reload's completion callback instead of fixed `sleep-for` delays.

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -131,6 +131,35 @@ the rendered tree as a `[text text-properties query-args]` triple, where `text`
 is the printable output, `text-properties` describes per-span coloring/metadata,
 and `query-args` is the printed query that produced it.
 
+### `sayid-get-workspace-data`
+
+Return the recorded call tree *as data* instead of pre-rendered text, for clients
+that want to render or analyze it themselves: an editor that isn't Emacs, a
+[Portal](https://github.com/djblue/portal) tap, a REPL one-liner. Takes no
+params. Replies with a `:value` that is a list of root call nodes, sent as native
+bencode data (real nested maps and lists, not a printed string), so you navigate
+it by key without reading anything back.
+
+Each node is a map with these string keys:
+
+| key | meaning |
+|-----|---------|
+| `id` | the call's id |
+| `name` | the fully qualified function name |
+| `depth` | nesting depth (1 for a root call) |
+| `started-at`, `ended-at` | capture timestamps, in milliseconds |
+| `args` | the arguments, each `pr-str`'d |
+| `arg-map` | arg name to `pr-str`'d value |
+| `return` | the return value, `pr-str`'d; absent if the call threw |
+| `throw` | present instead of `return` when the call threw: `{cause, class, data}` |
+| `file`, `line` | source location, for jumping to the definition |
+| `children` | the calls made within this one, same shape |
+
+The structural fields are native data; the captured values (`args`, `arg-map`,
+`return`, the `throw` parts) are printed strings, because an arbitrary Clojure
+value can't always round-trip over the wire. The rendered counterpart is
+`sayid-get-workspace`.
+
 ### `sayid-query`
 
 Run a query against the workspace. Param: `query` (a printed Clojure query

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -85,6 +85,14 @@
          (println e)))
   (send-status-done msg))
 
+(defn reply:data
+  "Reply with OUT sent as-is - no `clj->nrepl` flattening - and end the op.  For
+  the data ops, whose shapes are already built to round-trip over bencode."
+  [msg out]
+  (t/send (:transport msg)
+          (response-for msg :value out))
+  (send-status-done msg))
+
 (defn reply:error
   "Reply to MSG with a CIDER-renderable error response for EX and end the op.
 Mirrors the `:err'/`:ex' plus `:error'/`:done' status convention used by
@@ -503,6 +511,52 @@ or nil when nothing resolves there."
                     (sd/with-this-view (or @sd/view
                                       (v/mk-simple-view {}))
                       (query-tree->trio (sd/ws-view!)))))
+
+(defn throw->data
+  "Trim a captured `:throw` (a `Throwable->map`) to the bencode-friendly bits a
+  client needs: the message, the exception class, and any ex-data.  The full
+  stack trace stays out of the wire shape."
+  [thrown]
+  (->> {"cause" (:cause thrown)
+        "class" (some-> thrown :via first :type str)
+        "data"  (some-> thrown :data pr-str)}
+       (filter (comp some? val))
+       (into {})))
+
+(defn node->data
+  "Serialize one recorded call-tree NODE into a bencode-friendly map.  Structural
+  fields stay native (strings, ints, nested maps and lists) so a client can
+  navigate them directly; the arbitrary captured values - args, arg-map and the
+  return (or throw) - are `pr-str`'d, since they can't round-trip as data.  See
+  doc/nrepl-api.md for the documented shape."
+  [node]
+  (let [m (:meta node)
+        base {"id"         (some-> (:id node) name)
+              "name"       (some-> (:name node) str)
+              "depth"      (:depth node)
+              "started-at" (:started-at node)
+              "ended-at"   (:ended-at node)
+              "args"       (mapv pr-str (:args node))
+              "arg-map"    (reduce-kv (fn [acc k v]
+                                        (assoc acc (str k) (pr-str v)))
+                                      {} (:arg-map node))
+              "file"       (:file m)
+              "line"       (:line m)
+              "children"   (mapv node->data (:children node))}
+        outcome (if (contains? node :throw)
+                  {"throw" (throw->data (:throw node))}
+                  {"return" (pr-str (:return node))})]
+    (->> (merge base outcome)
+         (filter (comp some? val))
+         (into {}))))
+
+(defn ^:nrepl sayid-get-workspace-data
+  "Return the recorded call tree as data - a list of root call nodes, each a map
+  whose `children` are more such nodes - for clients that render it themselves.
+  The rendered counterpart is `sayid-get-workspace`; see doc/nrepl-api.md for the
+  shape."
+  [msg]
+  (reply:data msg (mapv node->data (:children (sd/ws-deref!)))))
 
 (defn magic-recusive-eval
   "Lets us send vars to nrepl client and back. Madness."

--- a/test/com/billpiel/sayid/nrepl_middleware_test.clj
+++ b/test/com/billpiel/sayid/nrepl_middleware_test.clj
@@ -16,7 +16,8 @@
             [com.billpiel.sayid.trace :as sdt]
             [com.billpiel.sayid.test-utils :as t-utils]
             [com.billpiel.sayid.test-ns1 :as ns1]
-            [nrepl.transport :as transport]))
+            [nrepl.transport :as transport]
+            [nrepl.bencode :as bencode]))
 
 (defn- recording-transport
   "An nREPL transport that records every sent message into ATOM."
@@ -139,3 +140,58 @@
 
 (t/deftest version-op-returns-the-version-string
   (t/is (= sd/version (captured-value "sayid-version" {}))))
+
+;;; --- Data ops (initiative 3) ------------------------------------------------
+
+(defn- bencode-roundtrips?
+  "True if V survives a real bencode write then read - the encodability check the
+  recording transport can't do, since it never serializes."
+  [v]
+  (let [out (java.io.ByteArrayOutputStream.)]
+    (bencode/write-bencode out v)
+    (-> (java.io.ByteArrayInputStream. (.toByteArray out))
+        java.io.PushbackInputStream.
+        bencode/read-bencode
+        some?)))
+
+(t/deftest get-workspace-data-returns-a-native-tree
+  (t/testing "sayid-get-workspace-data ships the call tree as data, not a trio"
+    (sd/ws-add-trace-ns! ns1)
+    (ns1/func1 :a)
+    (let [value (captured-value "sayid-get-workspace-data" {})
+          root (first value)]
+      (t/is (= 1 (count value)) "one root call was recorded")
+      (t/testing "; structural fields are native and navigable"
+        (t/is (map? root))
+        (t/is (str/includes? (get root "name") "func1"))
+        (t/is (int? (get root "depth")))
+        (t/is (vector? (get root "children"))))
+      (t/testing "; captured values are pr-str'd"
+        (t/is (= ":a" (get root "return")))
+        (t/is (= [":a"] (get root "args")))
+        (t/is (= {"arg1" ":a"} (get root "arg-map"))))
+      (t/testing "; children are nested data nodes"
+        (t/is (str/includes? (get (first (get root "children")) "name")
+                             "func2"))))))
+
+(t/deftest get-workspace-data-is-wire-encodable
+  (t/testing "the value bencodes cleanly - no nils or unencodable values"
+    (sd/ws-add-trace-ns! ns1)
+    (ns1/func1 :a)
+    (t/is (bencode-roundtrips? (captured-value "sayid-get-workspace-data" {})))))
+
+(t/deftest node->data-captures-throws
+  (t/testing "a node that threw carries a trimmed throw and no return"
+    (let [data (mw/node->data
+                {:id :7 :name 'ns/boom :depth 1 :args [7] :arg-map '{x 7}
+                 :children []
+                 :throw {:cause "boom"
+                         :via [{:type 'clojure.lang.ExceptionInfo
+                                :message "boom"}]
+                         :data {:x 7}}})]
+      (t/is (not (contains? data "return"))
+            "a thrown call has no return value")
+      (let [thrown (get data "throw")]
+        (t/is (= "boom" (get thrown "cause")))
+        (t/is (= "clojure.lang.ExceptionInfo" (get thrown "class")))
+        (t/is (= "{:x 7}" (get thrown "data")) "ex-data is pr-str'd")))))


### PR DESCRIPTION
First of initiative 3's data ops (return data, not pre-rendered strings).

`sayid-get-workspace-data` returns the recorded call tree as native bencode data - a list of root call nodes, each a map whose `children` are more such nodes - instead of the `[text, properties, query-args]` trio `sayid-get-workspace` ships. Structural fields (id, name, depth, timings, file/line) stay navigable data; the arbitrary captured values (args, arg-map, return, or a trimmed throw) are `pr-str`'d, since they can't round-trip as data.

That's enough for an editor-agnostic client, a Portal tap, or a `(->> ... )` REPL one-liner to fetch and navigate a workspace without any Sayid-specific rendering. The rendered ops are untouched, so the Emacs client keeps working.

Verified it bencodes cleanly over a real transport (a test guards that, since the recording transport never serializes). Documented in doc/nrepl-api.md. Full suite green, clj-kondo clean.