### PR TITLE
Add data variants of the query ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#101](https://github.com/clojure-emacs/sayid/pull/101): Add data variants of the query ops (`sayid-query-data`, `sayid-query-by-id-data`, `sayid-query-by-fn-data`) that return matched calls as data instead of rendered text.
 * [#100](https://github.com/clojure-emacs/sayid/pull/100): Add the `sayid-get-workspace-data` nREPL op, which returns the recorded call tree as data (see [doc/nrepl-api.md](doc/nrepl-api.md)) for editor-agnostic clients.
 
 ## [0.3.0] - 2026-06-29

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -166,6 +166,12 @@ Run a query against the workspace. Param: `query` (a printed Clojure query
 form). Replies with the same `[text properties query-args]` triple as
 `sayid-get-workspace`.
 
+### `sayid-query-data`
+
+Data counterpart of `sayid-query`. Same `query` param, but replies with the
+matched calls as a list of node-data maps (the `sayid-get-workspace-data` shape)
+instead of the rendered triple.
+
 ### `sayid-query-form-at-point`
 
 Query the workspace for the calls that best match the cursor context. Params:
@@ -182,10 +188,20 @@ Query for a recorded call by id, optionally with a modifier.
 
 Replies with a `[text properties query-args]` triple.
 
+### `sayid-query-by-id-data`
+
+Data counterpart of `sayid-query-by-id`. Same `trace-id` and `mod` params,
+replies with node data (the `sayid-get-workspace-data` shape).
+
 ### `sayid-query-by-fn`
 
 Like the above, but selects by function name. Params: `fn-name`, `mod`. Replies
 with a `[text properties query-args]` triple.
+
+### `sayid-query-by-fn-data`
+
+Data counterpart of `sayid-query-by-fn`. Same `fn-name` and `mod` params,
+replies with node data (the `sayid-get-workspace-data` shape).
 
 ## Acting on a recorded call
 

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -315,15 +315,21 @@ or nil when nothing resolves there."
                     (-> (sd/ws-query-by-file-pos file line)
                         so/tree->text-prop-pair)))
 
-(defn sayid-buf-query
+(defn buf-query-tree
+  "Build and run a buffer query.  Q-VEC is the base query; MOD-STR an optional
+  modifier like \"a\" (ancestors) or \"d3\" (descendants, depth 3).  Returns the
+  result tree, which `query-tree->trio` renders or `query-tree->data` turns into
+  data."
   [q-vec mod-str]
-  (let [[_ sk sn] (re-find #"(\w+)\s*(\d+)?" mod-str)
+  (let [[_ sk sn] (re-find #"(\w+)\s*(\d+)?" (or mod-str ""))
         k (keyword sk)
         n (util/->int sn)
         query (remove nil? [k n q-vec])]
-    (sd/with-view (->> query
-                       (apply query*)
-                       query-tree->trio))))
+    (apply query* query)))
+
+(defn sayid-buf-query
+  [q-vec mod-str]
+  (sd/with-view (query-tree->trio (buf-query-tree q-vec mod-str))))
 
 (defn ^:nrepl sayid-query-by-id
   [{:keys [trace-id mod] :as msg}]
@@ -558,6 +564,12 @@ or nil when nothing resolves there."
   [msg]
   (reply:data msg (mapv node->data (:children (sd/ws-deref!)))))
 
+(defn query-tree->data
+  "The data counterpart of `query-tree->trio`: the tree's matched calls as a list
+  of `node->data` maps."
+  [tree]
+  (mapv node->data (:children tree)))
+
 (defn magic-recusive-eval
   "Lets us send vars to nrepl client and back. Madness."
   [frm]
@@ -565,15 +577,37 @@ or nil when nothing resolves there."
         (seq? frm) (eval frm)
         :else frm))
 
+(defn run-query
+  "Parse a printed QUERY form (a string), eval any embedded vars via
+  `magic-recusive-eval`, and run it.  Returns the result tree."
+  [query]
+  (->> query
+       read-string
+       (map magic-recusive-eval)
+       (apply query*)))
+
 (defn ^:nrepl sayid-query
-  [{:keys [transport query] :as msg}]
+  [{:keys [query] :as msg}]
   ;; TODO default to name-only view for empty query?
-  (sd/with-view (->> query
-                     read-string
-                     (map magic-recusive-eval)
-                     (apply query*)
-                     query-tree->trio
-                     (reply:clj->nrepl msg))))
+  (reply:clj->nrepl msg (sd/with-view (query-tree->trio (run-query query)))))
+
+(defn ^:nrepl sayid-query-data
+  "Data counterpart of `sayid-query`: run QUERY and return the matched calls as
+  node data.  See doc/nrepl-api.md."
+  [{:keys [query] :as msg}]
+  (reply:data msg (query-tree->data (run-query query))))
+
+(defn ^:nrepl sayid-query-by-id-data
+  "Data counterpart of `sayid-query-by-id`."
+  [{:keys [trace-id mod] :as msg}]
+  (reply:data msg (query-tree->data
+                   (buf-query-tree [:id (keyword trace-id)] mod))))
+
+(defn ^:nrepl sayid-query-by-fn-data
+  "Data counterpart of `sayid-query-by-fn`."
+  [{:keys [fn-name mod] :as msg}]
+  (reply:data msg (query-tree->data
+                   (buf-query-tree [#'parent-name-or-name (symbol fn-name)] mod))))
 
 (def sayid-nrepl-ops
   (->> *ns*

--- a/test/com/billpiel/sayid/nrepl_middleware_test.clj
+++ b/test/com/billpiel/sayid/nrepl_middleware_test.clj
@@ -195,3 +195,37 @@
         (t/is (= "boom" (get thrown "cause")))
         (t/is (= "clojure.lang.ExceptionInfo" (get thrown "class")))
         (t/is (= "{:x 7}" (get thrown "data")) "ex-data is pr-str'd")))))
+
+(t/deftest rendered-query-by-fn-still-returns-the-trio
+  (t/testing "splitting query-building out of sayid-query-by-fn keeps it rendering"
+    (sd/ws-add-trace-ns! ns1)
+    (ns1/func1 :a)
+    (let [value (captured-value "sayid-query-by-fn"
+                                {:fn-name "com.billpiel.sayid.test-ns1/func2"
+                                 :mod ""})
+          [text props query-args] value]
+      (t/is (= 3 (count value)) "still the three-element trio")
+      (t/is (string? text))
+      (t/is (str/includes? text "func2"))
+      (t/is (coll? props))
+      (t/is (string? query-args)))))
+
+(t/deftest query-data-ops-return-node-data
+  (sd/ws-add-trace-ns! ns1)
+  (ns1/func1 :a)
+  (t/testing "sayid-query-by-fn-data returns the matched calls as data"
+    (let [value (captured-value "sayid-query-by-fn-data"
+                                {:fn-name "com.billpiel.sayid.test-ns1/func2"
+                                 :mod ""})]
+      (t/is (= 1 (count value)))
+      (t/is (str/includes? (get (first value) "name") "func2"))
+      (t/is (= ":a" (get (first value) "return")))
+      (t/is (bencode-roundtrips? value) "the data bencodes cleanly")))
+  (t/testing "sayid-query-by-id-data returns the call subtree for an id"
+    (let [root-id (-> (sd/ws-deref!) :children first :id name)
+          value (captured-value "sayid-query-by-id-data" {:trace-id root-id :mod ""})]
+      (t/is (str/includes? (get (first value) "name") "func1"))))
+  (t/testing "sayid-query-data runs a query and returns data"
+    (let [value (captured-value "sayid-query-data" {:query "()"})]
+      (t/is (seq value))
+      (t/is (str/includes? (get (first value) "name") "func1")))))


### PR DESCRIPTION
Continues initiative 3. The query ops now have data counterparts - `sayid-query-data`, `sayid-query-by-id-data`, `sayid-query-by-fn-data` - that return the matched calls as node data (the `sayid-get-workspace-data` shape) instead of the rendered trio. That's what lets a client use the full query DSL and get data back, not just dump the whole workspace.

The interesting part is *how*: query-building is separated from the finisher. `buf-query-tree` and `run-query` build and run a query into a result tree; `query-tree->trio` renders it (as before) and the new `query-tree->data` turns it into node data. The rendered ops are re-expressed on the same helpers, so rendering becomes a finisher *over* the data rather than a parallel path that owns its own presentation - the dependency inversion the rendered ops need for the long term. A characterization test pins that the rendered ops still produce the same trio.

Full suite green (40 tests), clj-kondo clean. Documented in doc/nrepl-api.md.