### PR TITLE
Move audit rendering into the render namespace

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -72,10 +72,10 @@ pass.
 
   Mostly there already: the engine has no upward deps, and once the stray unused
   require and a dead scratch block were removed, `query`/`view`/`string-output`
-  stopped reaching into the engine too. The one real breach left is the protocol
-  owning rendering - the middleware calls `string-output` to build text-property
-  pairs for Emacs. Closing that *is* initiative 3 (return data, not strings), so
-  the hard line gets finished there.
+  stopped reaching into the engine too. The last knot - the protocol owning
+  rendering - was untied in initiative 3: the middleware now returns data, or
+  calls a small `*->text-prop-pair` render API in `string-output`, instead of
+  composing rendering steps itself.
 
 **Risks:** `sayid_multifn` is AOT-compiled and the namespace names are part of the
 deployed contract; renames need deprecated forwarders. Inner-trace rewriting reads
@@ -119,11 +119,13 @@ That single decision is why there's one client and why the data can't flow into
 the modern Clojure inspection ecosystem.
 
 **Approach:**
-- Define a stable, documented data shape for a recorded call tree (ids, fn,
-  args, return, children, inner values, timings).
-- Add data-returning ops alongside the existing rendered ones; move rendering
-  into a `render` namespace the *client* can call, keeping the Emacs experience
-  identical.
+- *Done.* Documented a stable data shape for a recorded call tree (ids, fn, args,
+  arg-map, return or throw, children, timings) - see doc/nrepl-api.md.
+- *Done.* Added data ops alongside the rendered ones (`sayid-get-workspace-data`,
+  `sayid-query-data` and friends), and moved rendering composition into a small
+  `*->text-prop-pair` API in `string-output`, so the middleware no longer owns
+  it. The Emacs experience is unchanged; it can adopt the data ops where it helps.
+  Still open: exposing inner-trace captured values in the data shape.
 - Once data ops exist, the payoffs are nearly free: tap a workspace into
   [Portal](https://github.com/djblue/portal) / Reveal / Morse, or `(->> (ws-deref)
   (filter ...))` with plain Clojure and the existing query DSL.

--- a/src/com/billpiel/sayid/nrepl_middleware.clj
+++ b/src/com/billpiel/sayid/nrepl_middleware.clj
@@ -247,14 +247,10 @@ or nil when nothing resolves there."
   (send-status-done msg))
 
 (defn ^:nrepl sayid-show-traced
-  [{:keys [transport ns] :as msg}]
-  (let [audit (-> @sd/workspace :traced tr/audit-traces)
-        audit-view (if (not (or (nil? ns) (empty? ns)))
-                     (so/audit->ns-view audit (symbol ns))
-                     (so/audit->top-view audit))]
-    (->> audit-view
-         so/tokens->text-prop-pair
-         (reply:clj->nrepl msg))))
+  [{:keys [ns] :as msg}]
+  (reply:clj->nrepl msg
+                    (so/audit->text-prop-pair (-> @sd/workspace :traced tr/audit-traces)
+                                              ns)))
 
 (defn count-traces
   [trace-audit]

--- a/src/com/billpiel/sayid/string_output.clj
+++ b/src/com/billpiel/sayid/string_output.clj
@@ -660,3 +660,14 @@
        flatten
        (remove nil?)
        split-text-tag-coll))
+
+(defn audit->text-prop-pair
+  "Render a traced-fns AUDIT (from `trace/audit-traces`) to a `[text properties]`
+  pair.  When NS is a non-empty string, render that namespace's view; otherwise
+  the top summary.  Keeps the view-selection inside the render namespace so the
+  nREPL layer just asks for \"the rendered audit\"."
+  [audit ns]
+  (-> (if (not (or (nil? ns) (empty? ns)))
+        (audit->ns-view audit (symbol ns))
+        (audit->top-view audit))
+      tokens->text-prop-pair))

--- a/test/com/billpiel/sayid/nrepl_middleware_test.clj
+++ b/test/com/billpiel/sayid/nrepl_middleware_test.clj
@@ -229,3 +229,13 @@
     (let [value (captured-value "sayid-query-data" {:query "()"})]
       (t/is (seq value))
       (t/is (str/includes? (get (first value) "name") "func1")))))
+
+(t/deftest show-traced-renders-the-audit
+  (t/testing "sayid-show-traced returns a rendered [text properties] pair"
+    (sd/ws-add-trace-ns! ns1)
+    (let [value (captured-value "sayid-show-traced" {})
+          [text props] value]
+      (t/is (= 2 (count value)) "the rendered text/properties pair")
+      (t/is (string? text))
+      (t/is (str/includes? text "test-ns1") "names the traced namespace")
+      (t/is (coll? props)))))


### PR DESCRIPTION
Finishes the rendering side of initiative 3. `sayid-show-traced` was the one op still composing rendering in the protocol layer: it picked the ns-vs-top audit view and tokenized it to a text-property pair itself. That composition moves into `string-output` as `audit->text-prop-pair`.

After this, the middleware reaches the renderer through exactly three entry points - `tree->`, `audit->` and `value->text-prop-pair` - and composes none of its own rendering. Combined with the query finishers (`query-tree->trio` next to `query-tree->data`), rendering is now a finisher the protocol *calls*, not logic it *owns*.

Pure refactor: `show-traced`'s output is identical, pinned by a new characterization test. Full suite green (41 tests), clj-kondo clean. Roadmap updated to mark the rendering breach closed.