### PR TITLE
Drop the com.billpiel domain prefix from the namespaces

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -35,12 +35,12 @@
 
  ;; `defalias`/`defalias-macro` define a var, so treat them like `def` and the
  ;; generated aliases resolve.
- :lint-as {com.billpiel.sayid.util.other/defalias clojure.core/def
-           com.billpiel.sayid.util.other/defalias-macro clojure.core/def
+ :lint-as {sayid.util.other/defalias clojure.core/def
+           sayid.util.other/defalias-macro clojure.core/def
            ;; The trace macros take an unevaluated ns/fn symbol, which they
            ;; quote internally - treat them like `quote` so the symbol isn't
            ;; flagged as unresolved.
-           com.billpiel.sayid.core/ws-add-trace-ns! clojure.core/quote
-           com.billpiel.sayid.core/ws-remove-trace-ns! clojure.core/quote
-           com.billpiel.sayid.core/ws-add-trace-fn! clojure.core/quote
-           com.billpiel.sayid.core/ws-add-inner-trace-fn! clojure.core/quote}}
+           sayid.core/ws-add-trace-ns! clojure.core/quote
+           sayid.core/ws-remove-trace-ns! clojure.core/quote
+           sayid.core/ws-add-trace-fn! clojure.core/quote
+           sayid.core/ws-add-inner-trace-fn! clojure.core/quote}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#103](https://github.com/clojure-emacs/sayid/pull/103): Drop the `com.billpiel` domain prefix from all namespaces (`com.billpiel.sayid.*` -> `sayid.*`), including the injected middleware var (now `sayid.nrepl-middleware/wrap-sayid`). Breaking for code that requires the old namespaces directly; the bundled plugin and Emacs client are updated in lockstep. The Maven coordinates are unchanged.
 * [#101](https://github.com/clojure-emacs/sayid/pull/101): Add data variants of the query ops (`sayid-query-data`, `sayid-query-by-id-data`, `sayid-query-by-fn-data`) that return matched calls as data instead of rendered text.
 * [#100](https://github.com/clojure-emacs/sayid/pull/100): Add the `sayid-get-workspace-data` nREPL op, which returns the recorded call tree as data (see [doc/nrepl-api.md](doc/nrepl-api.md)) for editor-agnostic clients.
 

--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ A 3rd-party vim plugin also exists. See
 
 ## Using Sayid from the REPL
 
-You don't need Emacs or CIDER to use Sayid. The `com.billpiel.sayid.core`
+You don't need Emacs or CIDER to use Sayid. The `sayid.core`
 namespace (conventionally aliased to `sd`) is a complete API on its own. Trace
 a namespace or a function, exercise your code, then print the recorded
 workspace:
 
 ```clojure
-(require '[com.billpiel.sayid.core :as sd])
+(require '[sayid.core :as sd])
 
 (defn add [a b] (+ a b))
 (defn add-twice [a b] (+ (add a b) (add a b)))

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -1,6 +1,6 @@
 # Sayid nREPL API
 
-Sayid ships an nREPL middleware (`com.billpiel.sayid.nrepl-middleware/wrap-sayid`)
+Sayid ships an nREPL middleware (`sayid.nrepl-middleware/wrap-sayid`)
 that exposes its tracing engine over the wire. The bundled Emacs client talks to
 Sayid exclusively through these ops, and any other editor or tool can do the same.
 
@@ -19,7 +19,7 @@ Clojure CLI / `nrepl.server`:
 
 ```clojure
 (nrepl.server/start-server
- :handler (nrepl.server/default-handler #'com.billpiel.sayid.nrepl-middleware/wrap-sayid))
+ :handler (nrepl.server/default-handler #'sayid.nrepl-middleware/wrap-sayid))
 ```
 
 ## Conventions

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -10,7 +10,7 @@ a release starts with bumping all of them.
 Set the new version in:
 
 - `project.clj` - the `defproject` coordinate
-- `src/com/billpiel/sayid/core.clj` - `version`
+- `src/sayid/core.clj` - `version`
 - `src/sayid/plugin.clj` - `version`
 - `src/el/sayid.el` - the `Version:` header, `sayid-version`, and `sayid-injected-plugin-version`
 - `README.md` and `doc/nrepl-api.md` - the dependency snippets

--- a/project.clj
+++ b/project.clj
@@ -12,14 +12,14 @@
                  [org.clojure/tools.reader "1.6.0" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure]]]
 
-  :aot [com.billpiel.sayid.sayid-multifn]
+  :aot [sayid.sayid-multifn]
 
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :repl-options {:nrepl-middleware [com.billpiel.sayid.nrepl-middleware/wrap-sayid]}
+  :repl-options {:nrepl-middleware [sayid.nrepl-middleware/wrap-sayid]}
 
   :pedantic? :warn
 

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -164,7 +164,7 @@ To opt out, set `sayid-inject-dependencies-at-jack-in' to nil."
     (when (boundp 'cider-jack-in-dependencies)
       (cider-add-to-alist 'cider-jack-in-dependencies
                           "mx.cider/sayid" sayid-injected-plugin-version))
-    (add-to-list 'cider-jack-in-nrepl-middlewares "com.billpiel.sayid.nrepl-middleware/wrap-sayid")))
+    (add-to-list 'cider-jack-in-nrepl-middlewares "sayid.nrepl-middleware/wrap-sayid")))
 
 ;;;###autoload
 (with-eval-after-load 'cider

--- a/src/sayid/core.clj
+++ b/src/sayid/core.clj
@@ -1,16 +1,16 @@
-(ns com.billpiel.sayid.core
+(ns sayid.core
   (:require clojure.pprint
-            [com.billpiel.sayid.trace :as trace]
-            [com.billpiel.sayid.inner-trace :as itrace]
-            [com.billpiel.sayid.workspace :as ws]
-            [com.billpiel.sayid.recording :as rec]
-            [com.billpiel.sayid.query :as q]
-            [com.billpiel.sayid.view :as v]
-            [com.billpiel.sayid.util.find-ns :as find-ns]
-            [com.billpiel.sayid.string-output :as so]
-            [com.billpiel.sayid.profiling :as pro]
-            [com.billpiel.sayid.util.other :as util]
-            [com.billpiel.sayid.util.sym :as sym]))
+            [sayid.trace :as trace]
+            [sayid.inner-trace :as itrace]
+            [sayid.workspace :as ws]
+            [sayid.recording :as rec]
+            [sayid.query :as q]
+            [sayid.view :as v]
+            [sayid.util.find-ns :as find-ns]
+            [sayid.string-output :as so]
+            [sayid.profiling :as pro]
+            [sayid.util.other :as util]
+            [sayid.util.sym :as sym]))
 
 (def version
   "The current version of sayid as a string."

--- a/src/sayid/inner_trace.clj
+++ b/src/sayid/inner_trace.clj
@@ -1,8 +1,8 @@
-(ns com.billpiel.sayid.inner-trace
-  (:require [com.billpiel.sayid.util.other :as util :refer [$-]]
-            [com.billpiel.sayid.util.sym :as sym]
-            [com.billpiel.sayid.util.source :as src]
-            [com.billpiel.sayid.trace :as trace]
+(ns sayid.inner-trace
+  (:require [sayid.util.other :as util :refer [$-]]
+            [sayid.util.sym :as sym]
+            [sayid.util.source :as src]
+            [sayid.trace :as trace]
             clojure.pprint
             clojure.set
             clojure.string

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.nrepl-middleware
+(ns sayid.nrepl-middleware
   (:require
    [clojure.stacktrace :as st]
    clojure.string
@@ -6,14 +6,14 @@
    [clojure.tools.namespace.find :as ns-find]
    [clojure.tools.reader :as r]
    [clojure.tools.reader.reader-types :as rts]
-   [com.billpiel.sayid.core :as sd]
-   [com.billpiel.sayid.query :as q]
-   [com.billpiel.sayid.string-output :as so]
-   [com.billpiel.sayid.trace :as tr]
-   [com.billpiel.sayid.util.find-ns :as find-ns]
-   [com.billpiel.sayid.util.other :as util]
-   [com.billpiel.sayid.util.sym :as sym]
-   [com.billpiel.sayid.view :as v]
+   [sayid.core :as sd]
+   [sayid.query :as q]
+   [sayid.string-output :as so]
+   [sayid.trace :as tr]
+   [sayid.util.find-ns :as find-ns]
+   [sayid.util.other :as util]
+   [sayid.util.sym :as sym]
+   [sayid.view :as v]
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.misc :refer [response-for]]
    [nrepl.transport :as t]

--- a/src/sayid/plugin.clj
+++ b/src/sayid/plugin.clj
@@ -12,4 +12,4 @@
                  [['mx.cider/sayid version]])
       (update-in [:repl-options :nrepl-middleware]
                  (fnil into [])
-                 ['com.billpiel.sayid.nrepl-middleware/wrap-sayid])))
+                 ['sayid.nrepl-middleware/wrap-sayid])))

--- a/src/sayid/profiling.clj
+++ b/src/sayid/profiling.clj
@@ -1,7 +1,7 @@
-(ns com.billpiel.sayid.profiling
-  (:require [com.billpiel.sayid.trace :as tr]
-            [com.billpiel.sayid.recording :as rec]
-            [com.billpiel.sayid.util.other :as util]
+(ns sayid.profiling
+  (:require [sayid.trace :as tr]
+            [sayid.recording :as rec]
+            [sayid.util.other :as util]
             clojure.set
             [clojure.walk :as w]))
 

--- a/src/sayid/query.clj
+++ b/src/sayid/query.clj
@@ -1,8 +1,8 @@
-(ns com.billpiel.sayid.query
+(ns sayid.query
   (:require [clojure.zip :as z]
             clojure.set
             clojure.string
-            [com.billpiel.sayid.util.other :as util]))
+            [sayid.util.other :as util]))
 
 ;; === zipper iterators
 

--- a/src/sayid/recording.clj
+++ b/src/sayid/recording.clj
@@ -1,8 +1,8 @@
-(ns com.billpiel.sayid.recording
-  (:require [com.billpiel.sayid.workspace :as ws]
-            [com.billpiel.sayid.trace :as trace]
-            [com.billpiel.sayid.util.other :as util]
-            [com.billpiel.sayid.shelf :as shelf]))
+(ns sayid.recording
+  (:require [sayid.workspace :as ws]
+            [sayid.trace :as trace]
+            [sayid.util.other :as util]
+            [sayid.shelf :as shelf]))
 
 (def bad-slot-msg "Recording must have a symbol value in :rec-slot. Value was `%s`. Try `save-as!` instead.")
 (def unknown-type-msg "Unknown type. `rec` must be a recording, workspace or trace tree. Received a %s.")

--- a/src/sayid/sayid_multifn.clj
+++ b/src/sayid/sayid_multifn.clj
@@ -1,5 +1,5 @@
-(ns com.billpiel.sayid.sayid-multifn
-  (:gen-class :name com.billpiel.sayid.SayidMultiFn
+(ns sayid.sayid-multifn
+  (:gen-class :name sayid.SayidMultiFn
               :init init
               :constructors {[clojure.lang.IPersistentMap]
                              [String

--- a/src/sayid/shelf.clj
+++ b/src/sayid/shelf.clj
@@ -1,6 +1,6 @@
-(ns com.billpiel.sayid.shelf
-  (:require [com.billpiel.sayid.util.other :as util]
-            [com.billpiel.sayid.util.sym :as sym]))
+(ns sayid.shelf
+  (:require [sayid.util.other :as util]
+            [sayid.util.sym :as sym]))
 
 
 (defn save!

--- a/src/sayid/string_output.clj
+++ b/src/sayid/string_output.clj
@@ -1,7 +1,7 @@
-(ns com.billpiel.sayid.string-output
-  (:require [com.billpiel.sayid.view :as v]
-            [com.billpiel.sayid.util.other :as util]
-            [com.billpiel.sayid.util.source :as src]
+(ns sayid.string-output
+  (:require [sayid.view :as v]
+            [sayid.util.other :as util]
+            [sayid.util.source :as src]
             [tamarin.core :as tam]
             [clojure.zip :as z]
             clojure.set

--- a/src/sayid/trace.clj
+++ b/src/sayid/trace.clj
@@ -1,7 +1,7 @@
-(ns com.billpiel.sayid.trace
-  (:require [com.billpiel.sayid.util.other :as util]
-            [com.billpiel.sayid.util.sym :as sym])
-  (:import com.billpiel.sayid.SayidMultiFn))
+(ns sayid.trace
+  (:require [sayid.util.other :as util]
+            [sayid.util.sym :as sym])
+  (:import sayid.SayidMultiFn))
 
 (def ^:dynamic *trace-log-parent* nil)
 
@@ -107,7 +107,7 @@
 
 (defn shallow-tracer-multifn
   [{:keys [workspace qual-sym meta']} original-fn]
-  (com.billpiel.sayid.SayidMultiFn. {:original original-fn
+  (sayid.SayidMultiFn. {:original original-fn
                                      :trace-dispatch-fn (fn [f args]
                                                           (trace-fn-call workspace
                                                                          (symbol (str qual-sym "--DISPATCHER"))
@@ -186,7 +186,7 @@
 (defn trace-ns*
   [ns workspace]
   (when-let [ns (the-ns-safe ns)]
-    (when-not ('#{clojure.core com.billpiel.sayid.core} (ns-name ns))
+    (when-not ('#{clojure.core sayid.core} (ns-name ns))
       (let [ns-fns (->> ns ns-interns vals (filter (comp util/fn*? var-get)))]
         (doseq [f ns-fns]
           (trace-var* f

--- a/src/sayid/util/find_ns.clj
+++ b/src/sayid/util/find_ns.clj
@@ -1,5 +1,5 @@
-(ns com.billpiel.sayid.util.find-ns
-  (:require [com.billpiel.sayid.util.other :as util]))
+(ns sayid.util.find-ns
+  (:require [sayid.util.other :as util]))
 
 (defn unnest-symbol
   [s]

--- a/src/sayid/util/other.clj
+++ b/src/sayid/util/other.clj
@@ -1,8 +1,8 @@
-(ns com.billpiel.sayid.util.other
+(ns sayid.util.other
   "General-purpose helpers that don't have a more specific home.  Symbol and
   namespace helpers live in `util.sym`, source-reading in `util.source`."
   (:require [clojure.walk :as walk]
-            [com.billpiel.sayid.util.sym :as sym]))
+            [sayid.util.sym :as sym]))
 
 (defn ->int
   [v]
@@ -50,7 +50,7 @@
 (defn arg-matcher-fn
   [arglists]
   (when (not-empty arglists)
-    (let [arities (map #(list % '(com.billpiel.sayid.util.other/get-env)) ;; NOTE!  NS/get-env must match this ns
+    (let [arities (map #(list % '(sayid.util.other/get-env)) ;; NOTE!  NS/get-env must match this ns
                        arglists)
           fn1  `(fn ~@arities)]
       (eval fn1))))

--- a/src/sayid/util/source.clj
+++ b/src/sayid/util/source.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.util.source
+(ns sayid.util.source
   "Helpers for locating and reading the source of a function, used by inner
   tracing to recover the form it needs to instrument."
   (:require [clojure.tools.reader :as r]

--- a/src/sayid/util/sym.clj
+++ b/src/sayid/util/sym.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.util.sym
+(ns sayid.util.sym
   "Helpers for working with symbols and namespaces: qualifying and resolving
   symbols, and evaluating or macroexpanding forms in a given namespace."
   (:require [clojure.walk :as walk]))

--- a/src/sayid/view.clj
+++ b/src/sayid/view.clj
@@ -1,5 +1,5 @@
-(ns com.billpiel.sayid.view
-  (:require [com.billpiel.sayid.util.other :as util]))
+(ns sayid.view
+  (:require [sayid.util.other :as util]))
 
 
 ;; ==================================================================

--- a/src/sayid/workspace.clj
+++ b/src/sayid/workspace.clj
@@ -1,8 +1,8 @@
-(ns com.billpiel.sayid.workspace
-  (:require [com.billpiel.sayid.trace :as trace]
-            [com.billpiel.sayid.util.other :as util]
-            [com.billpiel.sayid.util.sym :as sym]
-            [com.billpiel.sayid.shelf :as shelf]))
+(ns sayid.workspace
+  (:require [sayid.trace :as trace]
+            [sayid.util.other :as util]
+            [sayid.util.sym :as sym]
+            [sayid.shelf :as shelf]))
 
 (def default-traced {:ns #{}
                        :fn #{}

--- a/test/sayid/core_test.clj
+++ b/test/sayid/core_test.clj
@@ -1,21 +1,21 @@
-(ns com.billpiel.sayid.core-test
+(ns sayid.core-test
   (:require [clojure.test :as t]
-            [com.billpiel.sayid.core :as sd]
-            [com.billpiel.sayid.trace :as sdt]
-            [com.billpiel.sayid.query :as sdq]
-            [com.billpiel.sayid.test-utils :as t-utils]
-            [com.billpiel.sayid.test-ns1 :as ns1]
-            [com.billpiel.sayid.string-output :as sds]))
+            [sayid.core :as sd]
+            [sayid.trace :as sdt]
+            [sayid.query :as sdq]
+            [sayid.test-utils :as t-utils]
+            [sayid.test-ns1 :as ns1]
+            [sayid.string-output :as sds]))
 
 
 (defn- fixture
   [f]
-  (sdt/untrace-ns* 'com.billpiel.sayid.test-ns1)
+  (sdt/untrace-ns* 'sayid.test-ns1)
   (with-out-str (sd/ws-reset!))
   (with-redefs [sdt/now (t-utils/mock-now-fn)
                 gensym (t-utils/mock-gensym-fn)]
     (f)
-    (sdt/untrace-ns* 'com.billpiel.sayid.test-ns1)))
+    (sdt/untrace-ns* 'sayid.test-ns1)))
 
 (t/use-fixtures :each fixture)
 
@@ -42,10 +42,10 @@
                                :file "FILE",
                                :line 4,
                                :name 'func2,
-                               :ns (the-ns 'com.billpiel.sayid.test-ns1)},
+                               :ns (the-ns 'sayid.test-ns1)},
                               :return :a,
                               :started-at 1
-                              :name 'com.billpiel.sayid.test-ns1/func2,
+                              :name 'sayid.test-ns1/func2,
                               :arg-map {'arg1 :a},
                               :id :12,
                               :ended-at 2
@@ -56,10 +56,10 @@
                              :file "FILE",
                              :line 8,
                              :name 'func1,
-                             :ns (the-ns 'com.billpiel.sayid.test-ns1)},
+                             :ns (the-ns 'sayid.test-ns1)},
                             :return :a,
                             :started-at 0
-                            :name 'com.billpiel.sayid.test-ns1/func1,
+                            :name 'sayid.test-ns1/func1,
                             :arg-map {'arg1 :a},
                             :id :11,
                             :ended-at 3
@@ -68,7 +68,7 @@
                           :id :root10,
                           :path [:root10],
                           :traced
-                          {:inner-fn #{}, :fn #{}, :ns #{'com.billpiel.sayid.test-ns1}},
+                          {:inner-fn #{}, :fn #{}, :ns #{'sayid.test-ns1}},
                           :ws-slot nil}]
       (t/is (= (-> trace
                    ((t-utils/redact-file-fn [:children 0 :meta :file]
@@ -87,23 +87,23 @@
 
 (t/deftest ed-all-traces
 
-  (sd/ws-add-trace-ns! com.billpiel.sayid.test-ns1)
+  (sd/ws-add-trace-ns! sayid.test-ns1)
 
   (t/testing "ws-disable-all-traces!"
     (sd/ws-disable-all-traces!)
-    (com.billpiel.sayid.test-ns1/func1 :a)
+    (sayid.test-ns1/func1 :a)
     (t/is (= (sd/ws-deref!)
              {:children []
               :depth 0
               :id :root10
               :path [:root10]
-              :traced {:inner-fn #{}, :fn #{}, :ns #{'com.billpiel.sayid.test-ns1}}
+              :traced {:inner-fn #{}, :fn #{}, :ns #{'sayid.test-ns1}}
               :ws-slot nil
               :arg-map nil})))
 
   (t/testing "ws-enable-all-traces!"
     (sd/ws-enable-all-traces!)
-    (com.billpiel.sayid.test-ns1/func1 :a)
+    (sayid.test-ns1/func1 :a)
 
     (t/is (= (-> (sd/ws-deref!)
                  ((t-utils/redact-file-fn [:children 0 :meta :file]
@@ -122,8 +122,8 @@
                                              :file "FILE"
                                              :line 4
                                              :name 'func2
-                                             :ns (the-ns 'com.billpiel.sayid.test-ns1)}
-                                      :name 'com.billpiel.sayid.test-ns1/func2
+                                             :ns (the-ns 'sayid.test-ns1)}
+                                      :name 'sayid.test-ns1/func2
                                       :path [:root10 :11 :12]
                                       :return :a
                                       :started-at 1}]
@@ -135,8 +135,8 @@
                                  :file "FILE"
                                  :line 8
                                  :name 'func1
-                                 :ns (the-ns 'com.billpiel.sayid.test-ns1)}
-                          :name 'com.billpiel.sayid.test-ns1/func1
+                                 :ns (the-ns 'sayid.test-ns1)}
+                          :name 'sayid.test-ns1/func1
                           :path [:root10 :11]
                           :return :a
                           :started-at 0}]
@@ -145,7 +145,7 @@
               :path [:root10]
               :traced {:inner-fn #{}
                        :fn #{}
-                       :ns #{'com.billpiel.sayid.test-ns1}}
+                       :ns #{'sayid.test-ns1}}
               :ws-slot nil}))))
 
 (t/deftest remove-all-traces
@@ -166,9 +166,9 @@
 
 (t/deftest exception-thrown
   (t/testing "exception thrown"
-    (let [trace-root (sd/ws-add-trace-ns! com.billpiel.sayid.test-ns1)
+    (let [trace-root (sd/ws-add-trace-ns! sayid.test-ns1)
           _ (try
-              (com.billpiel.sayid.test-ns1/func-throws :a)
+              (sayid.test-ns1/func-throws :a)
               (catch Throwable t))
           trace (sd/ws-deref!)]
 
@@ -177,7 +177,7 @@
                  {:depth 0
                   :id :root10
                   :path [:root10]
-                  :traced {:fn #{}, :ns #{'com.billpiel.sayid.test-ns1}, :inner-fn #{}}
+                  :traced {:fn #{}, :ns #{'sayid.test-ns1}, :inner-fn #{}}
                   :ws-slot nil
                   :arg-map nil})))
 
@@ -200,7 +200,7 @@
                   :depth 1
                   :ended-at 1
                   :id :11
-                  :name 'com.billpiel.sayid.test-ns1/func-throws
+                  :name 'sayid.test-ns1/func-throws
                   :path [:root10 :11]
                   :started-at 0
                   :meta {:arglists '([arg1])
@@ -208,13 +208,13 @@
                          :file "FILE"
                          :line 12
                          :name 'func-throws
-                         :ns (the-ns 'com.billpiel.sayid.test-ns1)}
+                         :ns (the-ns 'sayid.test-ns1)}
                   :arg-map {'arg1 :a}}))))))
 
 (t/deftest querying
   (t/testing "q macro"
-    (let [trace-root (sd/ws-add-trace-ns! com.billpiel.sayid.test-ns1)
-          _ (com.billpiel.sayid.test-ns1/func3-1 3 8)
+    (let [trace-root (sd/ws-add-trace-ns! sayid.test-ns1)
+          _ (sayid.test-ns1/func3-1 3 8)
           trace (sd/ws-deref!)]
 
       (t/testing "; find node by name and all parents"
@@ -241,8 +241,8 @@
                                                            :file "FILE"
                                                            :line 16
                                                            :name 'func3-4
-                                                           :ns (the-ns 'com.billpiel.sayid.test-ns1)}
-                                                    :name 'com.billpiel.sayid.test-ns1/func3-4
+                                                           :ns (the-ns 'sayid.test-ns1)}
+                                                    :name 'sayid.test-ns1/func3-4
                                                     :path [:root10 :11 :13 :15]
                                                     :return 8
                                                     :started-at 6}]
@@ -254,8 +254,8 @@
                                                :file "FILE"
                                                :line 28
                                                :name 'func3-3
-                                               :ns (the-ns 'com.billpiel.sayid.test-ns1)}
-                                        :name 'com.billpiel.sayid.test-ns1/func3-3
+                                               :ns (the-ns 'sayid.test-ns1)}
+                                        :name 'sayid.test-ns1/func3-3
                                         :path [:root10 :11 :13]
                                         :return 8
                                         :started-at 3}]
@@ -267,8 +267,8 @@
                                    :file "FILE"
                                    :line 33
                                    :name 'func3-1
-                                   :ns (the-ns 'com.billpiel.sayid.test-ns1)}
-                            :name 'com.billpiel.sayid.test-ns1/func3-1
+                                   :ns (the-ns 'sayid.test-ns1)}
+                            :name 'sayid.test-ns1/func3-1
                             :path [:root10 :11]
                             :return 13
                             :started-at 0}]
@@ -277,7 +277,7 @@
                 :path [:root10]
                 :traced {:inner-fn #{}
                          :fn #{}
-                         :ns #{'com.billpiel.sayid.test-ns1}}
+                         :ns #{'sayid.test-ns1}}
                 :ws-slot nil}))))))
 
 (t/deftest inner-trace-letfn
@@ -285,8 +285,8 @@
   ;; to throw "Syntax error compiling fn*", because the fn bindings of the
   ;; expanded `letfn*' form were wrapped with tracing forms.
   (t/testing "inner-tracing a letfn-using fn"
-    (sd/ws-add-inner-trace-fn! com.billpiel.sayid.test-ns1/func-letfn)
+    (sd/ws-add-inner-trace-fn! sayid.test-ns1/func-letfn)
     (t/testing "; doesn't throw and returns the right value"
-      (t/is (= 8 (com.billpiel.sayid.test-ns1/func-letfn 3))))
+      (t/is (= 8 (sayid.test-ns1/func-letfn 3))))
     (t/testing "; records the call"
       (t/is (= 1 (-> (sd/ws-deref!) :children count))))))

--- a/test/sayid/nrepl_middleware_test.clj
+++ b/test/sayid/nrepl_middleware_test.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.nrepl-middleware-test
+(ns sayid.nrepl-middleware-test
   "Tests for the nREPL middleware.
 
   Two parts: the wiring (ops registered, descriptor in sync, errors terminated
@@ -11,11 +11,11 @@
   workspace, so no live nREPL session is needed."
   (:require [clojure.test :as t]
             [clojure.string :as str]
-            [com.billpiel.sayid.nrepl-middleware :as mw]
-            [com.billpiel.sayid.core :as sd]
-            [com.billpiel.sayid.trace :as sdt]
-            [com.billpiel.sayid.test-utils :as t-utils]
-            [com.billpiel.sayid.test-ns1 :as ns1]
+            [sayid.nrepl-middleware :as mw]
+            [sayid.core :as sd]
+            [sayid.trace :as sdt]
+            [sayid.test-utils :as t-utils]
+            [sayid.test-ns1 :as ns1]
             [nrepl.transport :as transport]
             [nrepl.bencode :as bencode]))
 
@@ -29,13 +29,13 @@
 
 (defn- fixture
   [f]
-  (sdt/untrace-ns* 'com.billpiel.sayid.test-ns1)
+  (sdt/untrace-ns* 'sayid.test-ns1)
   (with-out-str (sd/ws-reset!))
   ;; Deterministic clock and ids, exactly like core-test and public-api-test.
   (with-redefs [sdt/now (t-utils/mock-now-fn)
                 gensym (t-utils/mock-gensym-fn)]
     (f)
-    (sdt/untrace-ns* 'com.billpiel.sayid.test-ns1)))
+    (sdt/untrace-ns* 'sayid.test-ns1)))
 
 (t/use-fixtures :each fixture)
 
@@ -201,7 +201,7 @@
     (sd/ws-add-trace-ns! ns1)
     (ns1/func1 :a)
     (let [value (captured-value "sayid-query-by-fn"
-                                {:fn-name "com.billpiel.sayid.test-ns1/func2"
+                                {:fn-name "sayid.test-ns1/func2"
                                  :mod ""})
           [text props query-args] value]
       (t/is (= 3 (count value)) "still the three-element trio")
@@ -215,7 +215,7 @@
   (ns1/func1 :a)
   (t/testing "sayid-query-by-fn-data returns the matched calls as data"
     (let [value (captured-value "sayid-query-by-fn-data"
-                                {:fn-name "com.billpiel.sayid.test-ns1/func2"
+                                {:fn-name "sayid.test-ns1/func2"
                                  :mod ""})]
       (t/is (= 1 (count value)))
       (t/is (str/includes? (get (first value) "name") "func2"))

--- a/test/sayid/public_api_test.clj
+++ b/test/sayid/public_api_test.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.public-api-test
+(ns sayid.public-api-test
   "Characterization tests that pin `core`'s public surface ahead of the
   core decouple/cleanup on the roadmap (see doc/roadmap.md, initiative 1).
 
@@ -9,21 +9,21 @@
   touches (`string-output`, `profiling`) that had no coverage."
   (:require [clojure.test :as t]
             [clojure.string :as str]
-            [com.billpiel.sayid.core :as sd]
-            [com.billpiel.sayid.trace :as sdt]
-            [com.billpiel.sayid.test-utils :as t-utils]
-            [com.billpiel.sayid.test-ns1 :as ns1]))
+            [sayid.core :as sd]
+            [sayid.trace :as sdt]
+            [sayid.test-utils :as t-utils]
+            [sayid.test-ns1 :as ns1]))
 
 (defn- fixture
   [f]
-  (sdt/untrace-ns* 'com.billpiel.sayid.test-ns1)
+  (sdt/untrace-ns* 'sayid.test-ns1)
   (with-out-str (sd/ws-reset!))
   ;; Mock the clock and gensym so timestamps and ids are deterministic, exactly
   ;; like `core-test` does.
   (with-redefs [sdt/now (t-utils/mock-now-fn)
                 gensym (t-utils/mock-gensym-fn)]
     (f)
-    (sdt/untrace-ns* 'com.billpiel.sayid.test-ns1)))
+    (sdt/untrace-ns* 'sayid.test-ns1)))
 
 (t/use-fixtures :each fixture)
 
@@ -48,7 +48,7 @@
 (t/deftest public-entry-points-resolve
   (t/testing "every documented public entry point still resolves in core"
     (doseq [sym public-entry-points]
-      (t/is (some? (ns-resolve 'com.billpiel.sayid.core sym))
+      (t/is (some? (ns-resolve 'sayid.core sym))
             (str sym " must remain part of core's public API")))))
 
 ;;; --- Rendering (string-output) ---------------------------------------------
@@ -84,12 +84,12 @@
     (ns1/func3-1 3 8)
     (let [profile (:profile (sd/pro-analyze (sd/ws-deref!)))]
       (t/testing "; covers the entry fn and a callee (keyed by namespaced keyword)"
-        (t/is (contains? profile :com.billpiel.sayid.test-ns1/func3-1))
-        (t/is (contains? profile :com.billpiel.sayid.test-ns1/func3-2)))
+        (t/is (contains? profile :sayid.test-ns1/func3-1))
+        (t/is (contains? profile :sayid.test-ns1/func3-2)))
       (t/testing "; the entry fn ran exactly once"
-        (t/is (= 1 (:count (get profile :com.billpiel.sayid.test-ns1/func3-1)))))
+        (t/is (= 1 (:count (get profile :sayid.test-ns1/func3-1)))))
       (t/testing "; records call counts and timing metrics"
-        (let [entry (get profile :com.billpiel.sayid.test-ns1/func3-2)]
+        (let [entry (get profile :sayid.test-ns1/func3-2)]
           (t/is (pos-int? (:count entry)))
           (t/is (number? (:net-time-sum entry)))
           (t/is (number? (:gross-time-sum entry))))))))

--- a/test/sayid/query_test.clj
+++ b/test/sayid/query_test.clj
@@ -1,8 +1,8 @@
-(ns com.billpiel.sayid.query-test
+(ns sayid.query-test
   (:require [clojure.test :as t]
-            [com.billpiel.sayid.core :as sd]
-            [com.billpiel.sayid.query :as q]
-            [com.billpiel.sayid.test-utils :as t-utils]))
+            [sayid.core :as sd]
+            [sayid.query :as q]
+            [sayid.test-utils :as t-utils]))
 
 (comment "
 

--- a/test/sayid/recording_test.clj
+++ b/test/sayid/recording_test.clj
@@ -1,8 +1,8 @@
-(ns com.billpiel.sayid.recording-test
+(ns sayid.recording-test
   (:require [clojure.test :as t]
-            [com.billpiel.sayid.recording :as r]
-            [com.billpiel.sayid.workspace :as w]
-            [com.billpiel.sayid.test-utils :as t-utils]))
+            [sayid.recording :as r]
+            [sayid.workspace :as w]
+            [sayid.test-utils :as t-utils]))
 
 (t/deftest recording
   (with-redefs [gensym (t-utils/mock-gensym-fn)]

--- a/test/sayid/test_ns1.clj
+++ b/test/sayid/test_ns1.clj
@@ -1,5 +1,5 @@
-(ns com.billpiel.sayid.test-ns1
-  (:require [com.billpiel.sayid.util.other :refer [$-]]))
+(ns sayid.test-ns1
+  (:require [sayid.util.other :refer [$-]]))
 
 (defn func2
   [arg1]

--- a/test/sayid/test_utils.clj
+++ b/test/sayid/test_utils.clj
@@ -1,4 +1,4 @@
-(ns com.billpiel.sayid.test-utils
+(ns sayid.test-utils
   (:require clojure.string))
 
 ;; https://github.com/Prismatic/plumbing/blob/6f9f1b6453ed2c978a619dc99bb0317d8c053141/src/plumbing/core.cljx#L356

--- a/test/sayid/workspace_test.clj
+++ b/test/sayid/workspace_test.clj
@@ -1,7 +1,7 @@
-(ns com.billpiel.sayid.workspace-test
+(ns sayid.workspace-test
   (:require [clojure.test :as t]
-            [com.billpiel.sayid.workspace :as ws]
-            [com.billpiel.sayid.test-utils :as t-utils]))
+            [sayid.workspace :as ws]
+            [sayid.test-utils :as t-utils]))
 
 (def ^:dynamic *shelf*)
 (def ^:dynamic *ws*)


### PR DESCRIPTION
Sayid's namespaces lived under one author's personal domain (`com.billpiel.sayid.*`). Now that it ships as `mx.cider/sayid` under clojure-emacs, this moves everything to a plain `sayid.*` prefix - `sayid.core`, `sayid.trace`, `sayid.nrepl-middleware`, etc. - and the gen-classed multifn to `sayid.SayidMultiFn`.

Mechanical, but a few non-require spots needed care and are covered: the gen-class `:name` and its import in `trace.clj`, the hardcoded `sayid.core` self-guard, the `:aot` directive, and the middleware wiring. The plugin, the Lein `:nrepl-middleware` entry, and the Emacs client's `cider-jack-in-nrepl-middlewares` injection all move to `sayid.nrepl-middleware/wrap-sayid` together, so jacking in still works.

The Maven coordinates are untouched - the deprecated `com.billpiel/sayid` groupId keeps its name on purpose.

Verified with a clean AOT compile (exercising `sayid.SayidMultiFn`), the full suite (41 tests), and clj-kondo - all green.

**Breaking** for code that requires the old namespaces or references the old middleware var directly.