### PR TITLE
Add a cider-tree-view workspace view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.4.0] - 2026-06-30
 
+* [#105](https://github.com/clojure-emacs/sayid/pull/105): Add `sayid-tree-view-workspace`, a client-rendered, foldable view of the recorded call tree built on CIDER's `cider-tree-view` and the new data ops. Bumps the minimum CIDER to 1.23.
 * [#103](https://github.com/clojure-emacs/sayid/pull/103): Drop the `com.billpiel` domain prefix from all namespaces (`com.billpiel.sayid.*` -> `sayid.*`), including the injected middleware var (now `sayid.nrepl-middleware/wrap-sayid`). Breaking for code that requires the old namespaces directly; the bundled plugin and Emacs client are updated in lockstep. The Maven coordinates are unchanged.
 * [#101](https://github.com/clojure-emacs/sayid/pull/101): Add data variants of the query ops (`sayid-query-data`, `sayid-query-by-id-data`, `sayid-query-by-fn-data`) that return matched calls as data instead of rendered text.
 * [#100](https://github.com/clojure-emacs/sayid/pull/100): Add the `sayid-get-workspace-data` nREPL op, which returns the recorded call tree as data (see [doc/nrepl-api.md](doc/nrepl-api.md)) for editor-agnostic clients.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; Version: 0.4.0
 ;; URL: https://github.com/clojure-emacs/sayid
-;; Package-Requires: ((emacs "28") (cider "1.0"))
+;; Package-Requires: ((emacs "28") (cider "1.23"))
 ;; Keywords: clojure, cider, debugger
 
 ;; Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,7 @@
 ;;; Code:
 
 (require 'cider)
+(require 'cider-tree-view)
 
 (defgroup sayid nil
   "Sayid is an advanced Clojure debugging tool."
@@ -249,7 +250,7 @@ Ensures a CIDER REPL with the middleware is available first, and routes the
 request through CIDER's sender so the active session and connection are
 resolved automatically."
   (sayid--ensure-available)
-  (cider-nrepl-send-sync-request request))
+  (cider-nrepl-sync-request request))
 
 (defun sayid-send-and-message (req &optional fail-msg)
   "Send REQ to nrepl and show results as message.  Show FAIL-MSG on failure."
@@ -491,6 +492,68 @@ selects one by nesting DEPTH, cycled from 0 to 9."
   (interactive)
   (sayid-req-insert-content (list "op" "sayid-query"
                                   "query" (sayid-peek-query-str))))
+
+
+;;; Tree view of the recorded workspace
+;;
+;; A client-rendered view built on `cider-tree-view': it fetches the call tree
+;; as data (the `sayid-get-workspace-data' op) and turns each recorded call into
+;; a foldable node, instead of replaying a server-rendered string.
+
+(defun sayid-tree--node-label (call)
+  "Build the fontified tree label for CALL, an nrepl-dict call node.
+Shows the call form with its return value, or the thrown cause when it threw."
+  (let* ((name (nrepl-dict-get call "name"))
+         (args (nrepl-dict-get call "args"))
+         (form (cider-font-lock-as-clojure
+                (format "(%s%s)"
+                        name
+                        (if args (concat " " (mapconcat #'identity args " ")) ""))))
+         (throw (nrepl-dict-get call "throw")))
+    (if throw
+        (concat form "  "
+                (propertize (format "!! %s" (nrepl-dict-get throw "cause"))
+                            'face 'error))
+      (concat form "  => "
+              (cider-font-lock-as-clojure (or (nrepl-dict-get call "return") "nil"))))))
+
+(defun sayid-tree--jump-to-source (call)
+  "Jump to the source location recorded in CALL."
+  (let* ((file (nrepl-dict-get call "file"))
+         (line (nrepl-dict-get call "line"))
+         (xfile (and file (sayid-find-existing-file file))))
+    (if xfile
+        (progn
+          (pop-to-buffer (find-file-noselect xfile))
+          (goto-char (point-min))
+          (when line (forward-line (1- line))))
+      (user-error "Source file not found: %s" (or file "<unknown>")))))
+
+(defun sayid-tree--make-node (call)
+  "Make a `cider-tree-view-node' from CALL, a `sayid-get-workspace-data' node.
+The whole CALL dict is stashed as the node value, so commands acting on the node
+can read its id, arguments and source location back."
+  (let ((children (nrepl-dict-get call "children")))
+    (cider-tree-view-node-create
+     :label (sayid-tree--node-label call)
+     :value call
+     :on-visit (lambda () (sayid-tree--jump-to-source call))
+     :children-fn (when children
+                    (lambda () (mapcar #'sayid-tree--make-node children))))))
+
+;;;###autoload
+(defun sayid-tree-view-workspace ()
+  "Show the recorded workspace as a navigable, foldable tree.
+Fetches the workspace via the `sayid-get-workspace-data' op and renders it with
+`cider-tree-view': TAB folds a call, RET jumps to its source, n/p move."
+  (interactive)
+  (let ((roots (sayid-req-get-value (list "op" "sayid-get-workspace-data"))))
+    (if roots
+        (with-current-buffer (cider-popup-buffer "*sayid-tree*" 'select
+                                                 'cider-tree-view-mode 'ancillary)
+          (cider-tree-view-render (mapcar #'sayid-tree--make-node roots)
+                                  "Sayid workspace"))
+      (user-error "The Sayid workspace is empty, or Sayid isn't loaded"))))
 
 ;;;###autoload
 (defun sayid-show-traced (&optional ns)

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -90,5 +90,42 @@
     (expect (substitute-command-keys "\\{sayid-mode-map}")
             :not :to-match "sayid-query-id-w-mod")))
 
+(describe "sayid-tree--node-label"
+  (it "renders the call form and its return value"
+    (let ((label (sayid-tree--node-label
+                  (nrepl-dict "name" "my.ns/foo" "args" '(":a" "1") "return" ":a"))))
+      (expect label :to-match "my.ns/foo")
+      (expect label :to-match "=>")
+      (expect label :to-match ":a")))
+  (it "falls back to nil when there is no recorded return"
+    (expect (sayid-tree--node-label (nrepl-dict "name" "my.ns/foo"))
+            :to-match "nil"))
+  (it "shows the thrown cause instead of a return when the call threw"
+    (let ((label (sayid-tree--node-label
+                  (nrepl-dict "name" "my.ns/boom" "args" '("7")
+                              "throw" (nrepl-dict "cause" "boom")))))
+      (expect label :to-match "boom")
+      (expect label :not :to-match "=>"))))
+
+(describe "sayid-tree--make-node"
+  (it "stashes the whole call dict as the node value"
+    (let* ((call (nrepl-dict "name" "my.ns/foo" "return" "1"))
+           (node (sayid-tree--make-node call)))
+      (expect (cider-tree-view-node-value node) :to-equal call)))
+  (it "is expandable only when the call has children"
+    (let ((leaf (sayid-tree--make-node (nrepl-dict "name" "f")))
+          (parent (sayid-tree--make-node
+                   (nrepl-dict "name" "f" "children"
+                               (list (nrepl-dict "name" "g"))))))
+      (expect (cider-tree-view-node-children-fn leaf) :to-be nil)
+      (expect (cider-tree-view-node-children-fn parent) :not :to-be nil)))
+  (it "builds child nodes from the call's children"
+    (let* ((call (nrepl-dict "name" "f" "children"
+                             (list (nrepl-dict "name" "g/child" "return" "2"))))
+           (node (sayid-tree--make-node call))
+           (children (funcall (cider-tree-view-node-children-fn node))))
+      (expect (length children) :to-equal 1)
+      (expect (cider-tree-view-node-label (car children)) :to-match "g/child"))))
+
 (provide 'sayid-test)
 ;;; sayid-test.el ends here


### PR DESCRIPTION
First step of dogfooding the new data ops in our own client. `sayid-tree-view-workspace` fetches the call tree via `sayid-get-workspace-data` and renders it with CIDER's `cider-tree-view`: each recorded call is a foldable node (TAB), RET jumps to its source, n/p navigate. The whole call dict rides along as the node's `value`, so the value-inspector handoff and query commands can hang off it next.

The point: the tree is now built **from data, in Elisp**, instead of replaying a server-rendered text+properties string. The existing `sayid-get-workspace` view is left untouched while we prove this one out.

Using `cider-tree-view` bumps the minimum CIDER to 1.23 (fine - we're effectively relaunching). That also surfaced one deprecation, fixed here: `cider-nrepl-send-sync-request` -> `cider-nrepl-sync-request`.

Pure data->node mapping is covered by new buttercup specs; the nREPL boundary stays Clojure-side. Full elisp build (compile + lint + 17 specs) green locally.