### PR TITLE
Add value inspection to the workspace tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.4.0] - 2026-06-30
 
-* [#105](https://github.com/clojure-emacs/sayid/pull/105): Add `sayid-tree-view-workspace`, a client-rendered, foldable view of the recorded call tree built on CIDER's `cider-tree-view` and the new data ops. Bumps the minimum CIDER to 1.23.
+* [#105](https://github.com/clojure-emacs/sayid/pull/105): Add `sayid-tree-view-workspace`, a client-rendered, foldable view of the recorded call tree built on CIDER's `cider-tree-view` and the new data ops. Bumps the minimum CIDER to 1.23. `i` inspects a call's captured value (return, throw, or a named argument) via `cider-inspect`.
 * [#103](https://github.com/clojure-emacs/sayid/pull/103): Drop the `com.billpiel` domain prefix from all namespaces (`com.billpiel.sayid.*` -> `sayid.*`), including the injected middleware var (now `sayid.nrepl-middleware/wrap-sayid`). Breaking for code that requires the old namespaces directly; the bundled plugin and Emacs client are updated in lockstep. The Maven coordinates are unchanged.
 * [#101](https://github.com/clojure-emacs/sayid/pull/101): Add data variants of the query ops (`sayid-query-data`, `sayid-query-by-id-data`, `sayid-query-by-fn-data`) that return matched calls as data instead of rendered text.
 * [#100](https://github.com/clojure-emacs/sayid/pull/100): Add the `sayid-get-workspace-data` nREPL op, which returns the recorded call tree as data (see [doc/nrepl-api.md](doc/nrepl-api.md)) for editor-agnostic clients.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -541,16 +541,63 @@ can read its id, arguments and source location back."
      :children-fn (when children
                     (lambda () (mapcar #'sayid-tree--make-node children))))))
 
+(defun sayid-tree--value-targets (call)
+  "Return an alist of (LABEL . PATH) naming the inspectable values of CALL.
+Each PATH is a `sayid-def-value' path into the recorded call: the return value,
+the thrown error, or a named argument."
+  (append
+   (when (nrepl-dict-get call "return") (list (cons "return" (list "return"))))
+   (when (nrepl-dict-get call "throw") (list (cons "throw" (list "throw"))))
+   (let ((arg-map (nrepl-dict-get call "arg-map")))
+     (when arg-map
+       (mapcar (lambda (name)
+                 (cons (format "arg %s" name) (list "arg-map" name)))
+               (nrepl-dict-keys arg-map))))))
+
+(defun sayid-tree-inspect (&optional arg)
+  "Inspect a captured value of the call at point with `cider-inspect'.
+Defs the value to `$s/*' server-side and hands the live object to CIDER's
+inspector.  By default inspects the return value (or the thrown error); with a
+prefix ARG, prompt for which value - the return, the throw, or a named argument."
+  (interactive "P")
+  (let* ((node (or (cider-tree-view-node-at-point)
+                   (user-error "No call at point")))
+         (call (cider-tree-view-node-value node))
+         (targets (sayid-tree--value-targets call))
+         (path (if arg
+                   (cdr (assoc (completing-read "Inspect value: " targets nil t)
+                               targets))
+                 (or (cdr (assoc "return" targets))
+                     (cdr (assoc "throw" targets))
+                     (user-error "This call has no return value to inspect")))))
+    (sayid-send-and-message (list "op" "sayid-def-value"
+                                  "trace-id" (nrepl-dict-get call "id")
+                                  "path" path))
+    (cider-inspect "$s/*")))
+
+(defvar sayid-tree-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "i") #'sayid-tree-inspect)
+    map)
+  "Keymap for `sayid-tree-mode', layered over `cider-tree-view-mode-map'.")
+
+(define-derived-mode sayid-tree-mode cider-tree-view-mode "Sayid-Tree"
+  "Major mode for the Sayid workspace tree.
+Inherits navigation and folding from `cider-tree-view-mode' and adds
+Sayid-specific actions: \\<sayid-tree-mode-map>\\[sayid-tree-inspect] inspects a
+captured value.")
+
 ;;;###autoload
 (defun sayid-tree-view-workspace ()
   "Show the recorded workspace as a navigable, foldable tree.
 Fetches the workspace via the `sayid-get-workspace-data' op and renders it with
-`cider-tree-view': TAB folds a call, RET jumps to its source, n/p move."
+`cider-tree-view': TAB folds a call, RET jumps to its source, n/p move, and
+\\<sayid-tree-mode-map>\\[sayid-tree-inspect] inspects a captured value."
   (interactive)
   (let ((roots (sayid-req-get-value (list "op" "sayid-get-workspace-data"))))
     (if roots
         (with-current-buffer (cider-popup-buffer "*sayid-tree*" 'select
-                                                 'cider-tree-view-mode 'ancillary)
+                                                 'sayid-tree-mode 'ancillary)
           (cider-tree-view-render (mapcar #'sayid-tree--make-node roots)
                                   "Sayid workspace"))
       (user-error "The Sayid workspace is empty, or Sayid isn't loaded"))))

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -127,5 +127,21 @@
       (expect (length children) :to-equal 1)
       (expect (cider-tree-view-node-label (car children)) :to-match "g/child"))))
 
+(describe "sayid-tree--value-targets"
+  (it "offers the return and each named argument, with their def-value paths"
+    (let ((targets (sayid-tree--value-targets
+                    (nrepl-dict "return" "42"
+                                "arg-map" (nrepl-dict "x" "1" "y" "2")))))
+      (expect (cdr (assoc "return" targets)) :to-equal '("return"))
+      (expect (cdr (assoc "arg x" targets)) :to-equal '("arg-map" "x"))
+      (expect (cdr (assoc "arg y" targets)) :to-equal '("arg-map" "y"))))
+  (it "offers the throw instead of a return when the call threw"
+    (let ((targets (sayid-tree--value-targets
+                    (nrepl-dict "throw" (nrepl-dict "cause" "boom")
+                                "arg-map" (nrepl-dict "x" "1")))))
+      (expect (assoc "return" targets) :to-be nil)
+      (expect (cdr (assoc "throw" targets)) :to-equal '("throw"))
+      (expect (cdr (assoc "arg x" targets)) :to-equal '("arg-map" "x")))))
+
 (provide 'sayid-test)
 ;;; sayid-test.el ends here


### PR DESCRIPTION
Second slice of the dogfood. `i` on a call node in `sayid-tree-view-workspace` defs the captured value to `$s/*` (via the existing `sayid-def-value` op) and hands the live object to `cider-inspect` - the exact handoff `sayid-buf-inspect-at-point` already does, now reading the call from the tree node's stashed `value`.

With no prefix it inspects the return (or the throw if it threw); with a prefix it prompts for which value - the return, the throw, or a named argument - and builds the right `sayid-def-value` path (`("return")`, `("throw")`, or `("arg-map" NAME)`).

The tree buffer now uses `sayid-tree-mode` (derived from `cider-tree-view-mode`), so folding and navigation carry over and there's a clean home for the Sayid-specific keys. Pure path-building is covered by new buttercup specs; full elisp build (compile + lint + 19 specs) green.

This turns the tree from a pretty viewer into something you can actually debug with: drill into any arg or return as a live, navigable object.