### PR TITLE
Expose inner-trace nodes correctly in the data shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.4.0] - 2026-06-30
 
+* [#108](https://github.com/clojure-emacs/sayid/pull/108): Fix the data ops misreporting inner-trace nodes: successful inner calls no longer come back as empty throws, and each node now exposes its recorded `form`.
 * [#105](https://github.com/clojure-emacs/sayid/pull/105): Add `sayid-tree-view-workspace`, a client-rendered, foldable view of the recorded call tree built on CIDER's `cider-tree-view` and the new data ops. Fold and navigate the tree, jump to a call's source, inspect any captured value (return, throw, or a named argument) in CIDER's inspector, and focus by function or call id. Bumps the minimum CIDER to 1.23.
 * [#103](https://github.com/clojure-emacs/sayid/pull/103): Drop the `com.billpiel` domain prefix from all namespaces (`com.billpiel.sayid.*` -> `sayid.*`), including the injected middleware var (now `sayid.nrepl-middleware/wrap-sayid`). Breaking for code that requires the old namespaces directly; the bundled plugin and Emacs client are updated in lockstep. The Maven coordinates are unchanged.
 * [#101](https://github.com/clojure-emacs/sayid/pull/101): Add data variants of the query ops (`sayid-query-data`, `sayid-query-by-id-data`, `sayid-query-by-fn-data`) that return matched calls as data instead of rendered text.

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -146,6 +146,7 @@ Each node is a map with these string keys:
 |-----|---------|
 | `id` | the call's id |
 | `name` | the fully qualified function name |
+| `form` | for an inner-trace node, the recorded source expression (absent for a plain call) |
 | `depth` | nesting depth (1 for a root call) |
 | `started-at`, `ended-at` | capture timestamps, in milliseconds |
 | `args` | the arguments, each `pr-str`'d |
@@ -153,7 +154,7 @@ Each node is a map with these string keys:
 | `return` | the return value, `pr-str`'d; absent if the call threw |
 | `throw` | present instead of `return` when the call threw: `{cause, class, data}` |
 | `file`, `line` | source location, for jumping to the definition |
-| `children` | the calls made within this one, same shape |
+| `children` | the calls (and, under an inner trace, the sub-expressions) made within this one, same shape |
 
 The structural fields are native data; the captured values (`args`, `arg-map`,
 `return`, the `throw` parts) are printed strings, because an arbitrary Clojure

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -502,19 +502,22 @@ selects one by nesting DEPTH, cycled from 0 to 9."
 
 (defun sayid-tree--node-label (call)
   "Build the fontified tree label for CALL, an nrepl-dict call node.
-Shows the call form with its return value, or the thrown cause when it threw."
-  (let* ((name (nrepl-dict-get call "name"))
-         (args (nrepl-dict-get call "args"))
-         (form (cider-font-lock-as-clojure
-                (format "(%s%s)"
-                        name
-                        (if args (concat " " (mapconcat #'identity args " ")) ""))))
+For an inner-trace node uses the recorded expression form; otherwise the call
+form.  Shows the return value, or the thrown cause when it threw."
+  (let* ((form (nrepl-dict-get call "form"))
+         (expr (cider-font-lock-as-clojure
+                (or form
+                    (let ((name (nrepl-dict-get call "name"))
+                          (args (nrepl-dict-get call "args")))
+                      (format "(%s%s)" name
+                              (if args (concat " " (mapconcat #'identity args " "))
+                                ""))))))
          (throw (nrepl-dict-get call "throw")))
     (if throw
-        (concat form "  "
+        (concat expr "  "
                 (propertize (format "!! %s" (nrepl-dict-get throw "cause"))
                             'face 'error))
-      (concat form "  => "
+      (concat expr "  => "
               (cider-font-lock-as-clojure (or (nrepl-dict-get call "return") "nil"))))))
 
 (defun sayid-tree--jump-to-source (call)

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -535,6 +535,7 @@ or nil when nothing resolves there."
   (let [m (:meta node)
         base {"id"         (some-> (:id node) name)
               "name"       (some-> (:name node) str)
+              "form"       (some-> (:form node) pr-str)
               "depth"      (:depth node)
               "started-at" (:started-at node)
               "ended-at"   (:ended-at node)
@@ -545,7 +546,10 @@ or nil when nothing resolves there."
               "file"       (:file m)
               "line"       (:line m)
               "children"   (mapv node->data (:children node))}
-        outcome (if (contains? node :throw)
+        ;; A node carries a `:throw` key only when it actually threw; on an
+        ;; inner-trace node the key is always present but nil, so test the value,
+        ;; not its presence, or every successful inner call looks like a throw.
+        outcome (if (not-empty (:throw node))
                   {"throw" (throw->data (:throw node))}
                   {"return" (pr-str (:return node))})]
     (->> (merge base outcome)

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -105,7 +105,13 @@
                   (nrepl-dict "name" "my.ns/boom" "args" '("7")
                               "throw" (nrepl-dict "cause" "boom")))))
       (expect label :to-match "boom")
-      (expect label :not :to-match "=>"))))
+      (expect label :not :to-match "=>")))
+  (it "uses the recorded form for an inner-trace node"
+    (let ((label (sayid-tree--node-label
+                  (nrepl-dict "name" "apply" "form" "(apply + (map inc xs))"
+                              "return" "9"))))
+      (expect label :to-match "map inc xs")
+      (expect label :to-match "9"))))
 
 (describe "sayid-tree--make-node"
   (it "stashes the whole call dict as the node value"

--- a/test/sayid/nrepl_middleware_test.clj
+++ b/test/sayid/nrepl_middleware_test.clj
@@ -196,6 +196,21 @@
         (t/is (= "clojure.lang.ExceptionInfo" (get thrown "class")))
         (t/is (= "{:x 7}" (get thrown "data")) "ex-data is pr-str'd")))))
 
+(t/deftest node->data-handles-inner-trace-nodes
+  (t/testing "an inner node exposes its form and keeps its return"
+    ;; Inner-trace nodes always carry a :throw key, nil unless they actually
+    ;; threw; the return must survive that.
+    (let [data (mw/node->data
+                {:id :9 :name 'apply :depth 2
+                 :form '(apply + (map inc xs))
+                 :throw nil :return 9
+                 :args [] :arg-map {} :children []})]
+      (t/is (= "(apply + (map inc xs))" (get data "form"))
+            "the source expression is exposed as the form")
+      (t/is (= "9" (get data "return")))
+      (t/is (not (contains? data "throw"))
+            "a nil :throw must not be reported as a throw"))))
+
 (t/deftest rendered-query-by-fn-still-returns-the-trio
   (t/testing "splitting query-building out of sayid-query-by-fn keeps it rendering"
     (sd/ws-add-trace-ns! ns1)


### PR DESCRIPTION
Found this while getting ready to make the tree view the default: inner tracing (the walkthrough's centerpiece) didn't survive the data ops.

`node->data` misread inner-trace nodes two ways:

1. It chose return-vs-throw with `(contains? node :throw)`, but an inner node *always* carries a `:throw` key (nil unless it actually threw). So every successful inner call came back as an empty `throw` with **no return** - a real bug in the raw data op, any client would see it.
2. It dropped the node's `:form`, so an inner expression showed up as its bare operator (`apply`, `map`) rather than the recorded form.

Fix: test the throw *value* (`not-empty`), not its presence, and expose `form`. The tree label then uses `form` for inner nodes, so `(map inc xs) => (2 3 4)` renders instead of `map`.

Characterization tests both sides (Clojure + buttercup), doc updated. This is the prerequisite for making the tree the default - which is next.

Full Clojure suite (42 tests), clj-kondo, and the elisp build (22 specs) all green.