### PR TITLE
Render show-traced as a tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.4.0] - 2026-06-30
 
+* [#110](https://github.com/clojure-emacs/sayid/pull/110): Render `sayid-show-traced` as a namespaces to functions tree (`cider-tree-view`), and add a `sayid-show-traced-data` op returning the traced audit as data.
 * [#108](https://github.com/clojure-emacs/sayid/pull/108): Fix the data ops misreporting inner-trace nodes: successful inner calls no longer come back as empty throws, and each node now exposes its recorded `form`.
 * [#105](https://github.com/clojure-emacs/sayid/pull/105): Add `sayid-tree-view-workspace`, a client-rendered, foldable view of the recorded call tree built on CIDER's `cider-tree-view` and the new data ops. Fold and navigate the tree, jump to a call's source, inspect any captured value (return, throw, or a named argument) in CIDER's inspector, and focus by function or call id. It's the default workspace view (`C-c s w`); the old text-rendered view stays available via `M-x sayid-get-workspace`. Bumps the minimum CIDER to 1.23.
 * [#103](https://github.com/clojure-emacs/sayid/pull/103): Drop the `com.billpiel` domain prefix from all namespaces (`com.billpiel.sayid.*` -> `sayid.*`), including the injected middleware var (now `sayid.nrepl-middleware/wrap-sayid`). Breaking for code that requires the old namespaces directly; the bundled plugin and Emacs client are updated in lockstep. The Maven coordinates are unchanged.

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -281,3 +281,10 @@ Replies with the distinct source roots of the loaded namespaces (e.g.
 
 Render the list of what's currently traced. Optional param: `ns` (limit to one
 namespace). Replies with the rendered tree.
+
+### `sayid-show-traced-data`
+
+Data counterpart of `sayid-show-traced`. Optional param: `ns`. Replies with a
+list of namespace groups, each a map of `{ns, fns}` where `fns` is a list of
+`{name, ns, file, line, trace-type}` maps - what's traced, as data for the client
+to render.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -649,14 +649,37 @@ actions: \\<sayid-tree-mode-map>\\[sayid-tree-query-fn] query the function at
 point, \\[sayid-tree-query-id] focus the call at point, \\[sayid-tree-inspect]
 inspect a value, \\[sayid-tree-view-workspace] back to the full workspace.")
 
+(defun sayid-traced--fn-node (fn)
+  "Make a `cider-tree-view-node' for a traced-function dict FN.
+RET jumps to the function's source."
+  (cider-tree-view-node-create
+   :label (cider-font-lock-as-clojure (nrepl-dict-get fn "name"))
+   :value fn
+   :on-visit (lambda () (sayid-tree--jump-to-source fn))))
+
+(defun sayid-traced--ns-node (group)
+  "Make a `cider-tree-view-node' for a traced-namespace GROUP.
+GROUP is a `{ns, fns}' dict from `sayid-show-traced-data'."
+  (let ((fns (nrepl-dict-get group "fns")))
+    (cider-tree-view-node-create
+     :label (propertize (nrepl-dict-get group "ns") 'face 'font-lock-type-face)
+     :expanded t
+     :children-fn (lambda () (mapcar #'sayid-traced--fn-node fns)))))
+
 ;;;###autoload
 (defun sayid-show-traced (&optional ns)
-  "Show what sayid has traced.  Optionally specify namespace NS."
+  "Show what Sayid has traced as a namespaces to functions tree.
+With NS, restrict to that namespace.  RET on a function jumps to its source."
   (interactive)
-  (sayid-select-traced-buf)
-  (sayid-req-insert-content (list "op" "sayid-show-traced"
-                                  "ns" ns))
-  (sayid-select-default-buf))
+  (let ((groups (sayid-req-get-value
+                 (append (list "op" "sayid-show-traced-data")
+                         (when ns (list "ns" ns))))))
+    (if groups
+        (with-current-buffer (cider-popup-buffer "*sayid-traced*" 'select
+                                                 'cider-tree-view-mode 'ancillary)
+          (cider-tree-view-render (mapcar #'sayid-traced--ns-node groups)
+                                  "Traced functions"))
+      (user-error "Nothing is traced"))))
 
 ;;;###autoload
 (defun sayid-show-traced-ns ()

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -252,6 +252,37 @@ or nil when nothing resolves there."
                     (so/audit->text-prop-pair (-> @sd/workspace :traced tr/audit-traces)
                                               ns)))
 
+(defn audit-fn->data
+  "Serialize one fn-info map from the traced audit to bencode data."
+  [fn-info]
+  (->> {"name"       (some-> (:name fn-info) str)
+        "ns"         (:ns fn-info)
+        "file"       (:file fn-info)
+        "line"       (:line fn-info)
+        "trace-type" (some-> (:trace-type fn-info) name)}
+       (filter (comp some? val))
+       (into {})))
+
+(defn audit->data
+  "Serialize a traced-fns AUDIT (from `trace/audit-traces`) to bencode data: a
+  list of namespace groups, each with the traced fns in it.  Merges the fns
+  traced by namespace and the ones traced individually."
+  [audit]
+  (mapv (fn [[ns-sym fns]]
+          {"ns"  (str ns-sym)
+           "fns" (mapv audit-fn->data (vals fns))})
+        (merge-with merge (:ns audit) (:fn audit))))
+
+(defn ^:nrepl sayid-show-traced-data
+  "Return what Sayid has traced as data - a list of namespace groups, each with
+  its traced functions - for clients that render it themselves.  With a non-empty
+  NS, restrict to that namespace.  The rendered counterpart is `sayid-show-traced`."
+  [{:keys [ns] :as msg}]
+  (let [groups (audit->data (-> @sd/workspace :traced tr/audit-traces))]
+    (reply:data msg (if (not-empty ns)
+                      (filterv #(= ns (get % "ns")) groups)
+                      groups))))
+
 (defn count-traces
   [trace-audit]
   (+ (count  (for [v1 (-> trace-audit :ns vals)

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -157,5 +157,18 @@
     (expect (sayid-tree--query-title "id" "42" "d3")
             :to-equal "Query: id 42 [d3]")))
 
+(describe "sayid-traced--ns-node"
+  (it "labels the group with its namespace and lists its functions as children"
+    (let* ((group (nrepl-dict "ns" "my.ns"
+                              "fns" (list (nrepl-dict "name" "foo"
+                                                      "file" "my/ns.clj" "line" 3))))
+           (node (sayid-traced--ns-node group))
+           (children (funcall (cider-tree-view-node-children-fn node))))
+      (expect (cider-tree-view-node-label node) :to-match "my.ns")
+      (expect (length children) :to-equal 1)
+      (expect (cider-tree-view-node-label (car children)) :to-match "foo")
+      (expect (cider-tree-view-node-value (car children)) :to-equal
+              (nrepl-dict "name" "foo" "file" "my/ns.clj" "line" 3)))))
+
 (provide 'sayid-test)
 ;;; sayid-test.el ends here

--- a/test/sayid/nrepl_middleware_test.clj
+++ b/test/sayid/nrepl_middleware_test.clj
@@ -254,3 +254,29 @@
       (t/is (string? text))
       (t/is (str/includes? text "test-ns1") "names the traced namespace")
       (t/is (coll? props)))))
+
+(t/deftest audit->data-groups-fns-by-namespace
+  (t/testing "audit->data merges ns- and individually-traced fns into ns groups"
+    (let [audit {:ns {'my.ns {'foo {:ns "my.ns" :name 'foo :file "my/ns.clj"
+                                    :line 3 :trace-type :fn}}}
+                 :fn {'my.ns {'bar {:ns "my.ns" :name 'bar :file "my/ns.clj"
+                                    :line 7 :trace-type :inner-fn}}}}
+          data (mw/audit->data audit)]
+      (t/is (= 1 (count data)) "one namespace group")
+      (let [group (first data)]
+        (t/is (= "my.ns" (get group "ns")))
+        (t/is (= #{"foo" "bar"} (set (map #(get % "name") (get group "fns"))))
+              "both the ns- and fn-traced functions appear under the namespace")
+        (let [foo (first (filter #(= "foo" (get % "name")) (get group "fns")))]
+          (t/is (= "my/ns.clj" (get foo "file")))
+          (t/is (= 3 (get foo "line")))
+          (t/is (= "fn" (get foo "trace-type"))))))))
+
+(t/deftest show-traced-data-returns-namespace-groups
+  (t/testing "the data op groups the traced fns by namespace"
+    (sd/ws-add-trace-ns! ns1)
+    (let [value (captured-value "sayid-show-traced-data" {})
+          group (first value)]
+      (t/is (= "sayid.test-ns1" (get group "ns")))
+      (t/is (some #(= "func1" (get % "name")) (get group "fns"))
+            "func1 is listed under its namespace"))))


### PR DESCRIPTION
`sayid-show-traced` (`C-c s s`) now renders as a tree too, matching the workspace view.

- New `sayid-show-traced-data` op returns the traced audit as data: a list of namespace groups, each a `{ns, fns}` map, merging the functions traced by namespace and individually (optional `ns` filter).
- The Emacs client renders it as a namespaces -> functions tree with `cider-tree-view`; `RET` on a function jumps to its source.

The rendered `sayid-show-traced` op is untouched (still there for any client that wants text).

Characterization tests both sides, doc updated. Full Clojure suite (44 tests), clj-kondo, and the elisp build (23 specs) all green.

Note: this orphans the old `*sayid-traced*` rendered-buffer machinery (its mode + trace-management commands). I'll clean that up in a follow-up - and can port the enable/disable/remove actions onto the traced tree if you want them there.