### PR TITLE
Add trace management to the traced tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* [#113](https://github.com/clojure-emacs/sayid/pull/113): Bring back trace management in the traced-functions view (`sayid-show-traced`): `e`/`d`/`r` enable, disable and remove the trace at point, `i`/`o` switch a function to an inner or outer trace.
+
 ## [0.4.0] - 2026-07-01
 
 * [#110](https://github.com/clojure-emacs/sayid/pull/110): Render `sayid-show-traced` as a namespaces to functions tree (`cider-tree-view`), and add a `sayid-show-traced-data` op returning the traced audit as data.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ own keybinding help.
 
 `C-c s s` (`sayid-show-traced`) shows what's traced as a namespaces to functions
 tree in the `*sayid-traced*` buffer. `RET` on a function jumps to its source;
-`TAB` folds a namespace, `n`/`p` move, `q` quits.
+`TAB` folds a namespace, `n`/`p` move, `q` quits. `e`/`d`/`r` enable, disable and
+remove the trace at point, and `i`/`o` switch a function to an inner or outer
+trace.
 
 
 In the `*sayid-pprint*` buffer, press `h` to pop up the help

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -657,20 +657,87 @@ GROUP is a `{ns, fns}' dict from `sayid-show-traced-data'."
   (let ((fns (nrepl-dict-get group "fns")))
     (cider-tree-view-node-create
      :label (propertize (nrepl-dict-get group "ns") 'face 'font-lock-type-face)
+     :value group
      :expanded t
      :children-fn (lambda () (mapcar #'sayid-traced--fn-node fns)))))
+
+(defun sayid-traced--apply (action)
+  "Apply trace ACTION to the entry at point in the traced tree, then refresh.
+On a function it applies the per-function op; on a bare namespace, the
+namespace-level op (only meaningful for enable, disable and remove)."
+  (let* ((node (or (cider-tree-view-node-at-point)
+                   (user-error "No traced entry at point")))
+         (entry (cider-tree-view-node-value node))
+         (fn-name (nrepl-dict-get entry "name")))
+    (cond
+     (fn-name
+      (sayid--send-sync-request (list "op" "sayid-trace-fn"
+                                      "action" action
+                                      "fn-name" fn-name
+                                      "fn-ns" (nrepl-dict-get entry "ns"))))
+     ((member action '("enable" "disable" "remove"))
+      (sayid--send-sync-request (list "op" "sayid-trace-ns"
+                                      "action" action
+                                      "ns" (nrepl-dict-get entry "ns"))))
+     (t (user-error "Point isn't on a function")))
+    (sayid-show-traced)))
+
+(defun sayid-traced-enable ()
+  "Enable the trace at point in the traced tree."
+  (interactive)
+  (sayid-traced--apply "enable"))
+
+(defun sayid-traced-disable ()
+  "Disable the trace at point in the traced tree."
+  (interactive)
+  (sayid-traced--apply "disable"))
+
+(defun sayid-traced-remove ()
+  "Remove the trace at point in the traced tree."
+  (interactive)
+  (sayid-traced--apply "remove"))
+
+(defun sayid-traced-inner-trace ()
+  "Switch the function at point to an inner trace."
+  (interactive)
+  (sayid-traced--apply "add-inner"))
+
+(defun sayid-traced-outer-trace ()
+  "Switch the function at point to an outer trace."
+  (interactive)
+  (sayid-traced--apply "add-outer"))
+
+(defvar sayid-traced-tree-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "e") #'sayid-traced-enable)
+    (define-key map (kbd "d") #'sayid-traced-disable)
+    (define-key map (kbd "r") #'sayid-traced-remove)
+    (define-key map (kbd "i") #'sayid-traced-inner-trace)
+    (define-key map (kbd "o") #'sayid-traced-outer-trace)
+    map)
+  "Keymap for `sayid-traced-tree-mode', layered over `cider-tree-view-mode-map'.")
+
+(define-derived-mode sayid-traced-tree-mode cider-tree-view-mode "Sayid-Traced"
+  "Major mode for the Sayid traced-functions tree.
+Inherits navigation and folding from `cider-tree-view-mode' and adds trace
+management: \\<sayid-traced-tree-mode-map>\\[sayid-traced-enable] enable,
+\\[sayid-traced-disable] disable, \\[sayid-traced-remove] remove,
+\\[sayid-traced-inner-trace] inner-trace, \\[sayid-traced-outer-trace]
+outer-trace the entry at point.")
 
 ;;;###autoload
 (defun sayid-show-traced (&optional ns)
   "Show what Sayid has traced as a namespaces to functions tree.
-With NS, restrict to that namespace.  RET on a function jumps to its source."
+With NS, restrict to that namespace.
+See `sayid-traced-tree-mode' for the keys (RET jumps to source; e/d/r/i/o
+manage traces)."
   (interactive)
   (let ((groups (sayid-req-get-value
                  (append (list "op" "sayid-show-traced-data")
                          (when ns (list "ns" ns))))))
     (if groups
         (with-current-buffer (cider-popup-buffer "*sayid-traced*" 'select
-                                                 'cider-tree-view-mode 'ancillary)
+                                                 'sayid-traced-tree-mode 'ancillary)
           (cider-tree-view-render (mapcar #'sayid-traced--ns-node groups)
                                   "Traced functions"))
       (user-error "Nothing is traced"))))

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -165,6 +165,8 @@
            (node (sayid-traced--ns-node group))
            (children (funcall (cider-tree-view-node-children-fn node))))
       (expect (cider-tree-view-node-label node) :to-match "my.ns")
+      ;; the group rides along so namespace-level actions can use it
+      (expect (cider-tree-view-node-value node) :to-equal group)
       (expect (length children) :to-equal 1)
       (expect (cider-tree-view-node-label (car children)) :to-match "foo")
       (expect (cider-tree-view-node-value (car children)) :to-equal


### PR DESCRIPTION
Restores the trace-management actions the old `*sayid-traced*` buffer had, which the 0.4.0 tree migration dropped.

`sayid-show-traced` now uses `sayid-traced-tree-mode` (derived from `cider-tree-view-mode`), which binds the familiar keys: `e`/`d`/`r` enable, disable and remove the trace at point, `i`/`o` switch a function to an inner or outer trace. They act on the function at point, or - for enable/disable/remove - on a namespace node, then refresh the tree. Namespace nodes now carry their group as the node value so the namespace-level ops have what they need.

Elisp-only; the `sayid-trace-fn`/`sayid-trace-ns` ops already existed. Build (compile + lint + 23 specs) green.