### PR TITLE
Cap the recording at a configurable number of top-level calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#114](https://github.com/clojure-emacs/sayid/pull/114): Cap the recording at `sayid.trace/*record-limit*` top-level calls (default 50k), so tracing a namespace under a test suite can't grow the workspace without bound. Calls past the cap run untraced and Sayid warns once.
 * [#113](https://github.com/clojure-emacs/sayid/pull/113): Bring back trace management in the traced-functions view (`sayid-show-traced`): `e`/`d`/`r` enable, disable and remove the trace at point, `i`/`o` switch a function to an inner or outer trace.
 
 ## [0.4.0] - 2026-07-01

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -94,13 +94,16 @@ inner expression value) with no cap, sampling, or eviction, and it captures live
 references rather than snapshots. That's why Sayid feels like a toy-example tool.
 
 **Approach:**
+- *Done (first cut).* A global cap on recorded top-level calls
+  (`trace/*record-limit*`, default 50k): once it's hit, further top-level calls
+  run untraced and Sayid warns once, so a `trace-ns` under a test suite can't grow
+  the recording without bound. Still to do here: per-fn caps, a ring-buffer /
+  eviction policy, and 1-in-N sampling.
 - Snapshot values at capture time honoring `*print-length*` / `*print-level*`
   (and a configurable size budget), so a fat map, a mutable object, or a lazy/
   infinite seq can't blow the heap or change after the fact.
-- Add bounds to `workspace`/`recording`: per-fn call caps, a global ring-buffer /
-  eviction policy, and optional sampling (record 1 in N calls).
 - Surface a clear signal when a bound kicks in ("hit the 1000-call cap on `foo`")
-  rather than silently truncating.
+  rather than silently truncating. *(Done for the global cap.)*
 
 **Risks:** snapshotting changes what users see for reference types; it must be
 opt-outable for the cases where you genuinely want the live value. Bounds interact

--- a/src/sayid/trace.clj
+++ b/src/sayid/trace.clj
@@ -5,6 +5,29 @@
 
 (def ^:dynamic *trace-log-parent* nil)
 
+(def ^:dynamic *record-limit*
+  "The maximum number of top-level (root) calls a single workspace will record.
+  Once the limit is reached, further top-level calls run untraced - the program
+  behaves normally, the calls are just not captured - so tracing a namespace
+  under a full test suite can't grow the recording without bound.  Rebind it or
+  `alter-var-root` it to record more (or fewer)."
+  50000)
+
+(defonce ^:private record-limit-hit (atom false))
+
+(defn reset-record-limit!
+  "Clear the once-per-workspace record-limit warning flag."
+  []
+  (reset! record-limit-hit false))
+
+(defn- warn-record-limit! []
+  (when (compare-and-set! record-limit-hit false true)
+    (binding [*out* *err*]
+      (println (str "Sayid: hit the " *record-limit* "-call recording limit; "
+                    "further top-level calls run untraced.  Clear or reset the "
+                    "workspace, or raise sayid.trace/*record-limit*, to record "
+                    "more.")))))
+
 (defn now [] (System/currentTimeMillis))
 
 (defn mk-tree
@@ -80,30 +103,36 @@
 
 (defn trace-fn-call
   [workspace name f args meta']
-  (let [parent (or *trace-log-parent*
-                   workspace)
-        this  (mk-fn-tree :parent parent ;; mk-fn-tree = 200ms
-                          :name name
-                          :args args
-                          :meta meta')
-        idx  (-> (start-trace (:children parent) ;; start-trace = 20ms
-                              this)
-                 count
-                 dec)]
-    (let [value (binding [*trace-log-parent* this] ;; binding = 50ms
-                  (try
-                    (apply f args)
-                    (catch Throwable t
-                      (end-trace (:children parent)
-                                 idx
-                                 {:throw (Throwable->map** t)
-                                  :ended-at (now)})
-                      (throw t))))]
-      (end-trace (:children parent) ;; end-trace = 75ms
-                 idx
-                 {:return value
-                  :ended-at (now)})
-      value)))
+  (if (and (nil? *trace-log-parent*)
+           (>= (count @(:children workspace)) *record-limit*))
+    ;; The recording is full.  Run the call untraced so the program still
+    ;; behaves, and warn once that we've stopped capturing.
+    (do (warn-record-limit!)
+        (apply f args))
+    (let [parent (or *trace-log-parent*
+                     workspace)
+          this  (mk-fn-tree :parent parent ;; mk-fn-tree = 200ms
+                            :name name
+                            :args args
+                            :meta meta')
+          idx  (-> (start-trace (:children parent) ;; start-trace = 20ms
+                                this)
+                   count
+                   dec)]
+      (let [value (binding [*trace-log-parent* this] ;; binding = 50ms
+                    (try
+                      (apply f args)
+                      (catch Throwable t
+                        (end-trace (:children parent)
+                                   idx
+                                   {:throw (Throwable->map** t)
+                                    :ended-at (now)})
+                        (throw t))))]
+        (end-trace (:children parent) ;; end-trace = 75ms
+                   idx
+                   {:return value
+                    :ended-at (now)})
+        value))))
 
 (defn shallow-tracer-multifn
   [{:keys [workspace qual-sym meta']} original-fn]

--- a/src/sayid/workspace.clj
+++ b/src/sayid/workspace.clj
@@ -48,14 +48,17 @@
 
 (defn reset-to-nil!
   [ws]
+  (trace/reset-record-limit!)
   (reset! ws nil))
 
 (defn new-log!
   [ws]
+  (trace/reset-record-limit!)
   (swap! ws assoc :children (atom [])))
 
 (defn clear-log!
   [ws]
+  (trace/reset-record-limit!)
   (reset! (:children @ws)
           []))
 

--- a/test/sayid/core_test.clj
+++ b/test/sayid/core_test.clj
@@ -290,3 +290,15 @@
       (t/is (= 8 (sayid.test-ns1/func-letfn 3))))
     (t/testing "; records the call"
       (t/is (= 1 (-> (sd/ws-deref!) :children count))))))
+
+(t/deftest record-limit-caps-recorded-root-calls
+  (t/testing "the recording stops growing at *record-limit* roots"
+    ;; Suppress the one-time \"recording is full\" warning to *err*.
+    (binding [sdt/*record-limit* 3
+              *err* (java.io.StringWriter.)]
+      (sd/ws-add-trace-ns! ns1)
+      (dotimes [_ 10] (ns1/func1 :a))
+      (t/testing "; calls past the cap still run and return normally"
+        (t/is (= :b (ns1/func1 :b))))
+      (t/testing "; only *record-limit* root calls are recorded"
+        (t/is (= 3 (-> (sd/ws-deref!) :children count)))))))


### PR DESCRIPTION
First cut of initiative 2 (bound the recording), targeting the headline adoption blocker: tracing a namespace and running a test suite could grow the workspace until it OOMs, because the recording held every top-level call with no bound.

New `sayid.trace/*record-limit*` (default 50k): once a workspace has recorded that many root calls, further top-level calls run *untraced* - the program behaves normally, the calls just aren't captured - and Sayid warns once to `*err*`. The warning flag resets whenever the log is cleared or the workspace is reset.

Deliberately narrow and safe:
- Only *top-level* calls are capped; nested calls under a recorded root are untouched.
- Value capture semantics are unchanged, so the `c i` inspector handoff and everything else still works.
- The limit is a dynamic var, so you can raise/lower it (or bind it) per run.

Still to come in this initiative: per-fn caps, a ring-buffer / eviction policy, 1-in-N sampling, and value snapshotting for the infinite-seq-at-view case. Roadmap updated to track that.

Full Clojure suite (45 tests) and clj-kondo green.