### PR TITLE
Bound value serialization in the data ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#115](https://github.com/clojure-emacs/sayid/pull/115): Serialize captured values in the data ops under bounded `*print-length*`/`*print-level*`, so a fat or infinite value can't hang the serializer or produce a runaway payload.
 * [#114](https://github.com/clojure-emacs/sayid/pull/114): Cap the recording at `sayid.trace/*record-limit*` top-level calls (default 50k), so tracing a namespace under a test suite can't grow the workspace without bound. Calls past the cap run untraced and Sayid warns once.
 * [#113](https://github.com/clojure-emacs/sayid/pull/113): Bring back trace management in the traced-functions view (`sayid-show-traced`): `e`/`d`/`r` enable, disable and remove the trace at point, `i`/`o` switch a function to an inner or outer trace.
 

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -158,7 +158,9 @@ Each node is a map with these string keys:
 
 The structural fields are native data; the captured values (`args`, `arg-map`,
 `return`, the `throw` parts) are printed strings, because an arbitrary Clojure
-value can't always round-trip over the wire. The rendered counterpart is
+value can't always round-trip over the wire. They're printed under bounded
+`*print-length*`/`*print-level*`, so a fat or infinite value produces a truncated
+string rather than a runaway payload. The rendered counterpart is
 `sayid-get-workspace`.
 
 ### `sayid-query`

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -101,7 +101,12 @@ references rather than snapshots. That's why Sayid feels like a toy-example tool
   eviction policy, and 1-in-N sampling.
 - Snapshot values at capture time honoring `*print-length*` / `*print-level*`
   (and a configurable size budget), so a fat map, a mutable object, or a lazy/
-  infinite seq can't blow the heap or change after the fact.
+  infinite seq can't blow the heap or change after the fact. *First cut done at
+  the serialization boundary: the data ops print captured values under bounded
+  `*print-length*`/`*print-level*` (`*value-print-length*`/`*value-print-level*`),
+  so an infinite seq can't hang the serializer or produce a runaway payload.
+  Capture-time snapshotting (to also cap heap and freeze reference types) is still
+  to do.*
 - Surface a clear signal when a bound kicks in ("hit the 1000-call cap on `foo`")
   rather than silently truncating. *(Done for the global cap.)*
 

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -545,6 +545,25 @@ or nil when nothing resolves there."
                                       (v/mk-simple-view {}))
                       (query-tree->trio (sd/ws-view!)))))
 
+(def ^:dynamic *value-print-length*
+  "`*print-length*` applied when serializing captured values in the data ops, so
+  a fat or infinite value produces a bounded string instead of hanging the
+  serializer.  nil means unbounded."
+  100)
+
+(def ^:dynamic *value-print-level*
+  "`*print-level*` applied when serializing captured values in the data ops."
+  10)
+
+(defn pr-value
+  "`pr-str` a captured value with the data-op print bounds applied, so an
+  arbitrarily large or lazy/infinite value can't blow up the wire payload or hang
+  the serializer."
+  [v]
+  (binding [*print-length* *value-print-length*
+            *print-level* *value-print-level*]
+    (pr-str v)))
+
 (defn throw->data
   "Trim a captured `:throw` (a `Throwable->map`) to the bencode-friendly bits a
   client needs: the message, the exception class, and any ex-data.  The full
@@ -552,7 +571,7 @@ or nil when nothing resolves there."
   [thrown]
   (->> {"cause" (:cause thrown)
         "class" (some-> thrown :via first :type str)
-        "data"  (some-> thrown :data pr-str)}
+        "data"  (some-> thrown :data pr-value)}
        (filter (comp some? val))
        (into {})))
 
@@ -570,9 +589,9 @@ or nil when nothing resolves there."
               "depth"      (:depth node)
               "started-at" (:started-at node)
               "ended-at"   (:ended-at node)
-              "args"       (mapv pr-str (:args node))
+              "args"       (mapv pr-value (:args node))
               "arg-map"    (reduce-kv (fn [acc k v]
-                                        (assoc acc (str k) (pr-str v)))
+                                        (assoc acc (str k) (pr-value v)))
                                       {} (:arg-map node))
               "file"       (:file m)
               "line"       (:line m)
@@ -582,7 +601,7 @@ or nil when nothing resolves there."
         ;; not its presence, or every successful inner call looks like a throw.
         outcome (if (not-empty (:throw node))
                   {"throw" (throw->data (:throw node))}
-                  {"return" (pr-str (:return node))})]
+                  {"return" (pr-value (:return node))})]
     (->> (merge base outcome)
          (filter (comp some? val))
          (into {}))))

--- a/test/sayid/nrepl_middleware_test.clj
+++ b/test/sayid/nrepl_middleware_test.clj
@@ -211,6 +211,14 @@
       (t/is (not (contains? data "throw"))
             "a nil :throw must not be reported as a throw"))))
 
+(t/deftest node->data-bounds-runaway-values
+  (t/testing "an infinite lazy seq is serialized to a bounded string, not a hang"
+    (let [data (mw/node->data {:id :1 :name 'f :return (range) :children []})
+          ret (get data "return")]
+      (t/is (string? ret))
+      (t/is (str/includes? ret "...") "the value is marked as truncated")
+      (t/is (< (count ret) 1000) "and its printed form is bounded"))))
+
 (t/deftest rendered-query-by-fn-still-returns-the-trio
   (t/testing "splitting query-building out of sayid-query-by-fn keeps it rendering"
     (sd/ws-add-trace-ns! ns1)


### PR DESCRIPTION
The second half of initiative 2's "capturing an infinite seq doesn't hang": the data ops `pr-str`'d captured values with no bound, so serializing a fat or infinite value (an unrealized `(range)`, say) produced a runaway wire payload or hung the serializer.

Now captured values (`args`, `arg-map`, `return`, and the throw's ex-data) are printed under bounded `*print-length*`/`*print-level*` via a small `pr-value` helper, configurable through `*value-print-length*` (default 100) and `*value-print-level*` (default 10). Source `form`s stay unbounded - they're finite.

Crucially, this is a *serialization*-side bound: value capture is untouched, so the `c i` inspector handoff still hands you the real, live object. Only the printed preview in the data/labels is truncated.

Test traces a node returning an infinite `(range)` and asserts the `return` string is bounded and marked truncated. Full Clojure suite (46 tests) and clj-kondo green.