### PR TITLE
Add a recording depth cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#116](https://github.com/clojure-emacs/sayid/pull/116): Add `sayid.trace/*max-trace-depth*` (default unbounded), which caps how deep the call nesting is recorded, so one deeply recursive call can't explode into an unbounded subtree.
 * [#115](https://github.com/clojure-emacs/sayid/pull/115): Serialize captured values in the data ops under bounded `*print-length*`/`*print-level*`, so a fat or infinite value can't hang the serializer or produce a runaway payload.
 * [#114](https://github.com/clojure-emacs/sayid/pull/114): Cap the recording at `sayid.trace/*record-limit*` top-level calls (default 50k), so tracing a namespace under a test suite can't grow the workspace without bound. Calls past the cap run untraced and Sayid warns once.
 * [#113](https://github.com/clojure-emacs/sayid/pull/113): Bring back trace management in the traced-functions view (`sayid-show-traced`): `e`/`d`/`r` enable, disable and remove the trace at point, `i`/`o` switch a function to an inner or outer trace.

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -94,11 +94,19 @@ inner expression value) with no cap, sampling, or eviction, and it captures live
 references rather than snapshots. That's why Sayid feels like a toy-example tool.
 
 **Approach:**
-- *Done (first cut).* A global cap on recorded top-level calls
-  (`trace/*record-limit*`, default 50k): once it's hit, further top-level calls
-  run untraced and Sayid warns once, so a `trace-ns` under a test suite can't grow
-  the recording without bound. Still to do here: per-fn caps, a ring-buffer /
-  eviction policy, and 1-in-N sampling.
+- *Done (first cut).* Two global caps, both running over-limit calls untraced:
+  `trace/*record-limit*` (default 50k) bounds the recorded top-level calls
+  (breadth - the test-suite case), and `trace/*max-trace-depth*` (default nil)
+  bounds how deep the call nesting is recorded, so one deeply recursive call can't
+  explode into an unbounded subtree. Still to do: per-fn caps, 1-in-N sampling,
+  and a ring-buffer / eviction policy.
+  - *Finding:* the record-limit and depth caps skip cleanly, but per-fn caps,
+    sampling and eviction all need a **recording-suppression flag** first - when a
+    *root* call is skipped and run untraced, its nested traced calls currently
+    masquerade as roots (the record-limit cap gets away with it only because those
+    calls also fail the limit). Building that suppression (and making inner
+    tracing honour it) is the prerequisite for the rest, and would also close a
+    latent nil-parent NPE when a skipped root calls an inner-traced fn.
 - Snapshot values at capture time honoring `*print-length*` / `*print-level*`
   (and a configurable size budget), so a fat map, a mutable object, or a lazy/
   infinite seq can't blow the heap or change after the fact. *First cut done at

--- a/src/sayid/trace.clj
+++ b/src/sayid/trace.clj
@@ -13,10 +13,18 @@
   `alter-var-root` it to record more (or fewer)."
   50000)
 
+(def ^:dynamic *max-trace-depth*
+  "The deepest call nesting a workspace will record; nil means unbounded.  Calls
+  below this depth (and everything under them) run untraced, so a deeply
+  recursive function or an inner trace can't explode a single call into an
+  unbounded subtree.  Root calls are depth 1."
+  nil)
+
 (defonce ^:private record-limit-hit (atom false))
 
-(defn reset-record-limit!
-  "Clear the once-per-workspace record-limit warning flag."
+(defn reset-bounds!
+  "Reset the per-workspace bound bookkeeping (the record-limit warning flag).
+  Called when the log is cleared or the workspace reset."
   []
   (reset! record-limit-hit false))
 
@@ -101,38 +109,52 @@
          [idx]
          #(merge % tree)))
 
+(defn record-fn-call
+  [parent name f args meta']
+  (let [this  (mk-fn-tree :parent parent
+                          :name name
+                          :args args
+                          :meta meta')
+        idx  (-> (start-trace (:children parent)
+                              this)
+                 count
+                 dec)]
+    (let [value (binding [*trace-log-parent* this]
+                  (try
+                    (apply f args)
+                    (catch Throwable t
+                      (end-trace (:children parent)
+                                 idx
+                                 {:throw (Throwable->map** t)
+                                  :ended-at (now)})
+                      (throw t))))]
+      (end-trace (:children parent)
+                 idx
+                 {:return value
+                  :ended-at (now)})
+      value)))
+
 (defn trace-fn-call
   [workspace name f args meta']
-  (if (and (nil? *trace-log-parent*)
-           (>= (count @(:children workspace)) *record-limit*))
-    ;; The recording is full.  Run the call untraced so the program still
-    ;; behaves, and warn once that we've stopped capturing.
-    (do (warn-record-limit!)
-        (apply f args))
-    (let [parent (or *trace-log-parent*
-                     workspace)
-          this  (mk-fn-tree :parent parent ;; mk-fn-tree = 200ms
-                            :name name
-                            :args args
-                            :meta meta')
-          idx  (-> (start-trace (:children parent) ;; start-trace = 20ms
-                                this)
-                   count
-                   dec)]
-      (let [value (binding [*trace-log-parent* this] ;; binding = 50ms
-                    (try
-                      (apply f args)
-                      (catch Throwable t
-                        (end-trace (:children parent)
-                                   idx
-                                   {:throw (Throwable->map** t)
-                                    :ended-at (now)})
-                        (throw t))))]
-        (end-trace (:children parent) ;; end-trace = 75ms
-                   idx
-                   {:return value
-                    :ended-at (now)})
-        value))))
+  (let [parent (or *trace-log-parent* workspace)]
+    (cond
+      ;; Too deep - drop this call and everything under it.  Nested calls hit the
+      ;; same check (their parent is still this one), so the whole subtree below
+      ;; the limit is skipped, keeping a single call from exploding the recording.
+      (and *max-trace-depth*
+           (> (inc (:depth parent)) *max-trace-depth*))
+      (apply f args)
+
+      ;; Root-level bound: the global record limit.
+      (nil? *trace-log-parent*)
+      (if (>= (count @(:children workspace)) *record-limit*)
+        (do (warn-record-limit!)
+            (apply f args))
+        (record-fn-call parent name f args meta'))
+
+      ;; A nested call under a recorded root.
+      :else
+      (record-fn-call parent name f args meta'))))
 
 (defn shallow-tracer-multifn
   [{:keys [workspace qual-sym meta']} original-fn]

--- a/src/sayid/workspace.clj
+++ b/src/sayid/workspace.clj
@@ -48,17 +48,17 @@
 
 (defn reset-to-nil!
   [ws]
-  (trace/reset-record-limit!)
+  (trace/reset-bounds!)
   (reset! ws nil))
 
 (defn new-log!
   [ws]
-  (trace/reset-record-limit!)
+  (trace/reset-bounds!)
   (swap! ws assoc :children (atom [])))
 
 (defn clear-log!
   [ws]
-  (trace/reset-record-limit!)
+  (trace/reset-bounds!)
   (reset! (:children @ws)
           []))
 

--- a/test/sayid/core_test.clj
+++ b/test/sayid/core_test.clj
@@ -302,3 +302,15 @@
         (t/is (= :b (ns1/func1 :b))))
       (t/testing "; only *record-limit* root calls are recorded"
         (t/is (= 3 (-> (sd/ws-deref!) :children count)))))))
+
+(t/deftest max-trace-depth-drops-nested-calls
+  (t/testing "*max-trace-depth* stops recording below the limit"
+    (binding [sdt/*max-trace-depth* 1]
+      (sd/ws-add-trace-ns! ns1)
+      (t/testing "; the call still runs normally"
+        (t/is (= :a (ns1/func1 :a))))
+      (let [roots (:children (sd/ws-deref!))]
+        (t/testing "; the root call is recorded"
+          (t/is (= 1 (count roots))))
+        (t/testing "; but its nested call (func2) is dropped"
+          (t/is (= 0 (-> roots first :children count))))))))


### PR DESCRIPTION
Another slice of initiative 2. `*record-limit*` (#114) bounds *breadth* (many top-level calls); this bounds *depth*.

New `sayid.trace/*max-trace-depth*` (default nil = unbounded): a call deeper than the limit, and everything under it, runs untraced. That covers the second OOM mode - a single deeply recursive call (or an inner trace) exploding into an unbounded subtree - which neither the breadth cap nor sampling would catch.

It's append-only and safe: a too-deep call keeps a real parent bound, so its nested calls see the same depth and skip too, without masquerading as roots.

Also refactors the recording body out of `trace-fn-call` into `record-fn-call`, so the bound checks read as a clean dispatch.

### On sampling

I built 1-in-N sampling too and then pulled it back out, because it stopped being an *easy, safe* win. Root-level skipping needs a recording-suppression flag first: when a root call is skipped and run untraced, its nested traced calls currently look like roots (the record-limit cap only gets away with it because those calls also fail the limit). That suppression - and making inner tracing honour it - is a small prerequisite that also closes a latent nil-parent NPE, so it deserves its own PR rather than being smuggled in here. The roadmap now tracks it.

Full Clojure suite (47 tests) and clj-kondo green.