### PR TITLE
Add recording suppression and 1-in-N sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#117](https://github.com/clojure-emacs/sayid/pull/117): Add `sayid.trace/*sample-rate*` (default 1), which records one in every N top-level calls, for tracing a hot entry point without drowning the recording. Backed by a recording-suppression flag that also fixes a latent NPE when a skipped root called an inner-traced function.
 * [#116](https://github.com/clojure-emacs/sayid/pull/116): Add `sayid.trace/*max-trace-depth*` (default unbounded), which caps how deep the call nesting is recorded, so one deeply recursive call can't explode into an unbounded subtree.
 * [#115](https://github.com/clojure-emacs/sayid/pull/115): Serialize captured values in the data ops under bounded `*print-length*`/`*print-level*`, so a fat or infinite value can't hang the serializer or produce a runaway payload.
 * [#114](https://github.com/clojure-emacs/sayid/pull/114): Cap the recording at `sayid.trace/*record-limit*` top-level calls (default 50k), so tracing a namespace under a test suite can't grow the workspace without bound. Calls past the cap run untraced and Sayid warns once.

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -94,19 +94,15 @@ inner expression value) with no cap, sampling, or eviction, and it captures live
 references rather than snapshots. That's why Sayid feels like a toy-example tool.
 
 **Approach:**
-- *Done (first cut).* Two global caps, both running over-limit calls untraced:
-  `trace/*record-limit*` (default 50k) bounds the recorded top-level calls
-  (breadth - the test-suite case), and `trace/*max-trace-depth*` (default nil)
-  bounds how deep the call nesting is recorded, so one deeply recursive call can't
-  explode into an unbounded subtree. Still to do: per-fn caps, 1-in-N sampling,
-  and a ring-buffer / eviction policy.
-  - *Finding:* the record-limit and depth caps skip cleanly, but per-fn caps,
-    sampling and eviction all need a **recording-suppression flag** first - when a
-    *root* call is skipped and run untraced, its nested traced calls currently
-    masquerade as roots (the record-limit cap gets away with it only because those
-    calls also fail the limit). Building that suppression (and making inner
-    tracing honour it) is the prerequisite for the rest, and would also close a
-    latent nil-parent NPE when a skipped root calls an inner-traced fn.
+- *Mostly done.* A `*suppress-recording*` flag is the foundation: skipping a call
+  now runs it (and its whole subtree) untraced without the nested calls leaking in
+  as spurious roots, and inner tracing honours it, which also closed a latent
+  nil-parent NPE. On top of it: `trace/*record-limit*` (default 50k) bounds the
+  recorded top-level calls (breadth), `trace/*max-trace-depth*` (default nil)
+  bounds recording depth, and `trace/*sample-rate*` (default 1) records one in
+  every N top-level calls for hot entry points. Still to do: per-fn caps and a
+  ring-buffer / eviction policy (the latter needs `end-trace` moved off positional
+  indices to node ids, or a documented single-threaded caveat).
 - Snapshot values at capture time honoring `*print-length*` / `*print-level*`
   (and a configurable size budget), so a fat map, a mutable object, or a lazy/
   infinite seq can't blow the heap or change after the fact. *First cut done at

--- a/src/sayid/inner_trace.clj
+++ b/src/sayid/inner_trace.clj
@@ -172,14 +172,17 @@
 
 (defn record-trace-tree!
   [tree-atom]
-  (let [children (some-> (@tree-atom [])
-                         deref-children
-                         :children
-                         deref)]
-    (doseq [child children]
-      (swap! (:children trace/*trace-log-parent*)
-             conj
-             child))))
+  ;; Honour the recording-suppression flag: inside a skipped call there may be no
+  ;; parent to attach to, and we don't want the inner values leaking in anyway.
+  (when-not trace/*suppress-recording*
+    (let [children (some-> (@tree-atom [])
+                           deref-children
+                           :children
+                           deref)]
+      (doseq [child children]
+        (swap! (:children trace/*trace-log-parent*)
+               conj
+               child)))))
 
 (defn get-temp-root-tree
   [path]

--- a/src/sayid/trace.clj
+++ b/src/sayid/trace.clj
@@ -20,13 +20,40 @@
   unbounded subtree.  Root calls are depth 1."
   nil)
 
+(def ^:dynamic *sample-rate*
+  "Record one in every N top-level calls; 1 (the default) records them all.  Set
+  higher to trace a hot entry point - say a request handler under load - and keep
+  only a representative sample instead of drowning the recording."
+  1)
+
+(def ^:dynamic *suppress-recording*
+  "When true, calls run untraced and nothing - outer or inner - is recorded.
+  Bound around a call Sayid chose to skip (over a limit, sampled out, too deep),
+  so the whole subtree under it is skipped instead of leaking in as spurious
+  roots.  This is what lets root-level bounds compose correctly."
+  false)
+
+(defn run-suppressed
+  "Run `(apply F ARGS)` with recording suppressed for it and everything under it."
+  [f args]
+  (binding [*suppress-recording* true]
+    (apply f args)))
+
 (defonce ^:private record-limit-hit (atom false))
 
+(defonce ^:private root-call-counter (atom 0))
+
 (defn reset-bounds!
-  "Reset the per-workspace bound bookkeeping (the record-limit warning flag).
-  Called when the log is cleared or the workspace reset."
+  "Reset the per-workspace bound bookkeeping - the record-limit warning flag and
+  the sampling counter.  Called when the log is cleared or the workspace reset."
   []
-  (reset! record-limit-hit false))
+  (reset! record-limit-hit false)
+  (reset! root-call-counter 0))
+
+(defn- sample-root?
+  "True when the current top-level call should be recorded under `*sample-rate*`."
+  []
+  (zero? (mod (swap! root-call-counter inc) *sample-rate*)))
 
 (defn- warn-record-limit! []
   (when (compare-and-set! record-limit-hit false true)
@@ -136,25 +163,33 @@
 
 (defn trace-fn-call
   [workspace name f args meta']
-  (let [parent (or *trace-log-parent* workspace)]
-    (cond
-      ;; Too deep - drop this call and everything under it.  Nested calls hit the
-      ;; same check (their parent is still this one), so the whole subtree below
-      ;; the limit is skipped, keeping a single call from exploding the recording.
-      (and *max-trace-depth*
-           (> (inc (:depth parent)) *max-trace-depth*))
-      (apply f args)
+  (if *suppress-recording*
+    ;; We're inside a call we chose not to record - stay untraced.
+    (apply f args)
+    (let [parent (or *trace-log-parent* workspace)]
+      (cond
+        ;; Too deep - drop this call and, via the suppression flag, everything
+        ;; under it, so a single call can't explode the recording.
+        (and *max-trace-depth*
+             (> (inc (:depth parent)) *max-trace-depth*))
+        (run-suppressed f args)
 
-      ;; Root-level bound: the global record limit.
-      (nil? *trace-log-parent*)
-      (if (>= (count @(:children workspace)) *record-limit*)
-        (do (warn-record-limit!)
-            (apply f args))
-        (record-fn-call parent name f args meta'))
+        ;; Root-level bounds: 1-in-N sampling, then the global record limit.
+        (nil? *trace-log-parent*)
+        (cond
+          (not (sample-root?))
+          (run-suppressed f args)
 
-      ;; A nested call under a recorded root.
-      :else
-      (record-fn-call parent name f args meta'))))
+          (>= (count @(:children workspace)) *record-limit*)
+          (do (warn-record-limit!)
+              (run-suppressed f args))
+
+          :else
+          (record-fn-call parent name f args meta'))
+
+        ;; A nested call under a recorded root.
+        :else
+        (record-fn-call parent name f args meta')))))
 
 (defn shallow-tracer-multifn
   [{:keys [workspace qual-sym meta']} original-fn]

--- a/test/sayid/core_test.clj
+++ b/test/sayid/core_test.clj
@@ -314,3 +314,22 @@
           (t/is (= 1 (count roots))))
         (t/testing "; but its nested call (func2) is dropped"
           (t/is (= 0 (-> roots first :children count))))))))
+
+(t/deftest sample-rate-records-one-in-n-root-calls
+  (t/testing "*sample-rate* records only one in every N top-level calls"
+    (binding [sdt/*sample-rate* 2]
+      (sd/ws-add-trace-ns! ns1)
+      (dotimes [_ 4] (ns1/func1 :a))
+      (t/is (= 2 (-> (sd/ws-deref!) :children count))))))
+
+(t/deftest suppressed-root-with-inner-trace-is-skipped-cleanly
+  (t/testing "a skipped root that calls an inner-traced fn records nothing, cleanly"
+    ;; Regression guard for the suppression fix: without it, the skipped root's
+    ;; nested calls leaked in as roots and inner tracing hit a nil parent.
+    (binding [sdt/*sample-rate* 1000]
+      (sd/ws-add-trace-fn! sayid.test-ns1/func1)
+      (sd/ws-add-inner-trace-fn! sayid.test-ns1/func2)
+      (t/testing "; the call still runs and returns normally"
+        (t/is (= :a (ns1/func1 :a))))
+      (t/testing "; and nothing is recorded"
+        (t/is (= 0 (-> (sd/ws-deref!) :children count)))))))


### PR DESCRIPTION
The foundation the remaining finer bounds needed, plus the first feature it unlocks.

**Suppression** - `sayid.trace/*suppress-recording*`. When Sayid skips a call, it now runs the call *and its whole subtree* with recording suppressed, so nested traced calls no longer masquerade as roots, and inner tracing honours the flag instead of dereferencing a possibly-nil parent. That closes a latent NPE (a skipped root calling an inner-traced fn). The existing record-limit and depth skips now route through `run-suppressed`.

**Sampling** - `sayid.trace/*sample-rate*` (default 1 = record all). Records one in every N top-level calls, for tracing a hot entry point (a request handler under load, say) without drowning the recording. Sampling is exactly what surfaced the root-leak bug in the first place; with suppression in place it now records the right count (2 of 4 at rate 2, not 4).

Tests cover the sampling count and a regression guard for the skipped-root-calls-inner-traced-fn case that used to NPE. Full Clojure suite (49 tests) and clj-kondo green.

Next on the initiative: per-fn caps (easy now), then eviction (needs `end-trace` moved off positional indices).