### PR TITLE
Add per-fn recording caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#118](https://github.com/clojure-emacs/sayid/pull/118): Add `sayid.trace/*per-fn-limit*` (default unbounded), which caps how many calls of any single function are recorded, so one hot function can't crowd out the rest of the recording.
 * [#117](https://github.com/clojure-emacs/sayid/pull/117): Add `sayid.trace/*sample-rate*` (default 1), which records one in every N top-level calls, for tracing a hot entry point without drowning the recording. Backed by a recording-suppression flag that also fixes a latent NPE when a skipped root called an inner-traced function.
 * [#116](https://github.com/clojure-emacs/sayid/pull/116): Add `sayid.trace/*max-trace-depth*` (default unbounded), which caps how deep the call nesting is recorded, so one deeply recursive call can't explode into an unbounded subtree.
 * [#115](https://github.com/clojure-emacs/sayid/pull/115): Serialize captured values in the data ops under bounded `*print-length*`/`*print-level*`, so a fat or infinite value can't hang the serializer or produce a runaway payload.

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -99,10 +99,12 @@ references rather than snapshots. That's why Sayid feels like a toy-example tool
   as spurious roots, and inner tracing honours it, which also closed a latent
   nil-parent NPE. On top of it: `trace/*record-limit*` (default 50k) bounds the
   recorded top-level calls (breadth), `trace/*max-trace-depth*` (default nil)
-  bounds recording depth, and `trace/*sample-rate*` (default 1) records one in
-  every N top-level calls for hot entry points. Still to do: per-fn caps and a
-  ring-buffer / eviction policy (the latter needs `end-trace` moved off positional
-  indices to node ids, or a documented single-threaded caveat).
+  bounds recording depth, `trace/*sample-rate*` (default 1) records one in every N
+  top-level calls for hot entry points, and `trace/*per-fn-limit*` (default nil)
+  caps how many calls of any single function are recorded so a hot function can't
+  crowd out the rest. Still to do: a ring-buffer / eviction policy (needs
+  `end-trace` moved off positional indices to node ids, or a documented
+  single-threaded caveat).
 - Snapshot values at capture time honoring `*print-length*` / `*print-level*`
   (and a configurable size budget), so a fat map, a mutable object, or a lazy/
   infinite seq can't blow the heap or change after the fact. *First cut done at

--- a/src/sayid/trace.clj
+++ b/src/sayid/trace.clj
@@ -33,6 +33,13 @@
   roots.  This is what lets root-level bounds compose correctly."
   false)
 
+(def ^:dynamic *per-fn-limit*
+  "The maximum number of calls of any single traced function a workspace will
+  record; nil means unbounded.  Counts across the whole call tree, so once a hot
+  function hits its limit, further calls of it (and everything under them) run
+  untraced and it can't crowd out the rest of the recording."
+  nil)
+
 (defn run-suppressed
   "Run `(apply F ARGS)` with recording suppressed for it and everything under it."
   [f args]
@@ -43,17 +50,43 @@
 
 (defonce ^:private root-call-counter (atom 0))
 
+(defonce ^:private per-fn-counts (atom {}))
+
+(defonce ^:private per-fn-warned (atom #{}))
+
 (defn reset-bounds!
-  "Reset the per-workspace bound bookkeeping - the record-limit warning flag and
-  the sampling counter.  Called when the log is cleared or the workspace reset."
+  "Reset the per-workspace bound bookkeeping - the record-limit warning flag, the
+  sampling counter, and the per-fn call counts.  Called when the log is cleared or
+  the workspace reset."
   []
   (reset! record-limit-hit false)
-  (reset! root-call-counter 0))
+  (reset! root-call-counter 0)
+  (reset! per-fn-counts {})
+  (reset! per-fn-warned #{}))
 
 (defn- sample-root?
   "True when the current top-level call should be recorded under `*sample-rate*`."
   []
   (zero? (mod (swap! root-call-counter inc) *sample-rate*)))
+
+(defn- over-per-fn-limit?
+  "True when NAME has already been recorded `*per-fn-limit*` times."
+  [name]
+  (and *per-fn-limit*
+       (>= (get @per-fn-counts name 0) *per-fn-limit*)))
+
+(defn- bump-per-fn-count!
+  "Count another recorded call of NAME when a per-fn limit is in effect."
+  [name]
+  (when *per-fn-limit*
+    (swap! per-fn-counts update name (fnil inc 0))))
+
+(defn- warn-per-fn-limit! [name]
+  (when-not (contains? @per-fn-warned name)
+    (swap! per-fn-warned conj name)
+    (binding [*out* *err*]
+      (println (str "Sayid: hit the " *per-fn-limit* "-call cap on " name
+                    "; further calls of it run untraced.")))))
 
 (defn- warn-record-limit! []
   (when (compare-and-set! record-limit-hit false true)
@@ -138,6 +171,7 @@
 
 (defn record-fn-call
   [parent name f args meta']
+  (bump-per-fn-count! name)
   (let [this  (mk-fn-tree :parent parent
                           :name name
                           :args args
@@ -168,6 +202,11 @@
     (apply f args)
     (let [parent (or *trace-log-parent* workspace)]
       (cond
+        ;; This function has hit its per-fn cap - drop it and its subtree.
+        (over-per-fn-limit? name)
+        (do (warn-per-fn-limit! name)
+            (run-suppressed f args))
+
         ;; Too deep - drop this call and, via the suppression flag, everything
         ;; under it, so a single call can't explode the recording.
         (and *max-trace-depth*

--- a/test/sayid/core_test.clj
+++ b/test/sayid/core_test.clj
@@ -322,6 +322,16 @@
       (dotimes [_ 4] (ns1/func1 :a))
       (t/is (= 2 (-> (sd/ws-deref!) :children count))))))
 
+(t/deftest per-fn-limit-caps-calls-of-each-function
+  (t/testing "*per-fn-limit* records at most N calls of a given function"
+    ;; Suppress the one-time per-fn cap warning to *err*.
+    (binding [sdt/*per-fn-limit* 2
+              *err* (java.io.StringWriter.)]
+      (sd/ws-add-trace-ns! ns1)
+      (dotimes [_ 5] (ns1/func1 :a))
+      (t/is (= 2 (-> (sd/ws-deref!) :children count))
+            "only *per-fn-limit* calls of func1 are recorded, the rest run untraced"))))
+
 (t/deftest suppressed-root-with-inner-trace-is-skipped-cleanly
   (t/testing "a skipped root that calls an inner-traced fn records nothing, cleanly"
     ;; Regression guard for the suppression fix: without it, the skipped root's


### PR DESCRIPTION
Next finer bound, easy now that suppression exists. `sayid.trace/*per-fn-limit*` (default nil) caps how many calls of any single function are recorded, counted across the whole tree. Once a function hits its cap, further calls of it and their subtrees run untraced, and Sayid warns once naming the function.

Where `*record-limit*` bounds total breadth and `*sample-rate*` thins a hot entry point, this keeps a hot *helper* (called in a tight loop deep in the tree) from crowding everything else out - you still get up to N of each function instead of a flood of one.

Full Clojure suite (50 tests) and clj-kondo green. Only eviction is left in the initiative.