### PR TITLE
Add keep-last-N eviction for the recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#119](https://github.com/clojure-emacs/sayid/pull/119): Add `sayid.trace/*evict-old-calls*` (default false), which switches the record limit from keeping the first N top-level calls to a keep-the-last-N ring, evicting the oldest.
 * [#118](https://github.com/clojure-emacs/sayid/pull/118): Add `sayid.trace/*per-fn-limit*` (default unbounded), which caps how many calls of any single function are recorded, so one hot function can't crowd out the rest of the recording.
 * [#117](https://github.com/clojure-emacs/sayid/pull/117): Add `sayid.trace/*sample-rate*` (default 1), which records one in every N top-level calls, for tracing a hot entry point without drowning the recording. Backed by a recording-suppression flag that also fixes a latent NPE when a skipped root called an inner-traced function.
 * [#116](https://github.com/clojure-emacs/sayid/pull/116): Add `sayid.trace/*max-trace-depth*` (default unbounded), which caps how deep the call nesting is recorded, so one deeply recursive call can't explode into an unbounded subtree.

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -94,17 +94,17 @@ inner expression value) with no cap, sampling, or eviction, and it captures live
 references rather than snapshots. That's why Sayid feels like a toy-example tool.
 
 **Approach:**
-- *Mostly done.* A `*suppress-recording*` flag is the foundation: skipping a call
-  now runs it (and its whole subtree) untraced without the nested calls leaking in
-  as spurious roots, and inner tracing honours it, which also closed a latent
-  nil-parent NPE. On top of it: `trace/*record-limit*` (default 50k) bounds the
-  recorded top-level calls (breadth), `trace/*max-trace-depth*` (default nil)
-  bounds recording depth, `trace/*sample-rate*` (default 1) records one in every N
-  top-level calls for hot entry points, and `trace/*per-fn-limit*` (default nil)
-  caps how many calls of any single function are recorded so a hot function can't
-  crowd out the rest. Still to do: a ring-buffer / eviction policy (needs
-  `end-trace` moved off positional indices to node ids, or a documented
-  single-threaded caveat).
+- *Done.* A `*suppress-recording*` flag is the foundation: skipping a call now
+  runs it (and its whole subtree) untraced without the nested calls leaking in as
+  spurious roots, and inner tracing honours it, which also closed a latent
+  nil-parent NPE. On top of it, a full set of bounds: `trace/*record-limit*`
+  (default 50k) bounds the recorded top-level calls (breadth), `trace/*max-trace-depth*`
+  (default nil) bounds recording depth, `trace/*sample-rate*` (default 1) records
+  one in every N top-level calls for hot entry points, `trace/*per-fn-limit*`
+  (default nil) caps how many calls of any single function are recorded, and
+  `trace/*evict-old-calls*` switches the record limit from keep-first-N to a
+  keep-last-N ring (the root end-trace is looked up by node id, not position, so
+  eviction is safe even with concurrent root calls).
 - Snapshot values at capture time honoring `*print-length*` / `*print-level*`
   (and a configurable size budget), so a fat map, a mutable object, or a lazy/
   infinite seq can't blow the heap or change after the fact. *First cut done at

--- a/src/sayid/trace.clj
+++ b/src/sayid/trace.clj
@@ -40,6 +40,14 @@
   untraced and it can't crowd out the rest of the recording."
   nil)
 
+(def ^:dynamic *evict-old-calls*
+  "How the workspace behaves at `*record-limit*` top-level calls.  When false (the
+  default) it stops recording and keeps the *first* `*record-limit*` calls.  When
+  true it keeps the *most recent* `*record-limit*` calls instead, evicting the
+  oldest - handy when the interesting thing is what happened just before a
+  failure at the end of a long run."
+  false)
+
 (defn run-suppressed
   "Run `(apply F ARGS)` with recording suppressed for it and everything under it."
   [f args]
@@ -169,6 +177,54 @@
          [idx]
          #(merge % tree)))
 
+(defn- roots-index-by-id
+  "Index of the root with :id ID in ROOTS, or nil when it's been evicted."
+  [roots id]
+  (loop [i 0]
+    (cond (>= i (count roots)) nil
+          (= (:id (nth roots i)) id) i
+          :else (recur (inc i)))))
+
+(defn- end-root-trace
+  "Merge TREE into the root with :id ID.  Looked up by id, not position, so it's
+  correct even when eviction has shifted the vector; a no-op if that root was
+  already evicted."
+  [ws-children id tree]
+  (swap! ws-children
+         (fn [roots]
+           (if-let [i (roots-index-by-id roots id)]
+             (update roots i #(merge % tree))
+             roots))))
+
+(defn record-root-call-evicting
+  "Record a top-level call while keeping only the most recent `*record-limit*`
+  roots: append this call and drop the oldest beyond the limit.  Ends by id, so
+  the index-shifting from eviction can't corrupt an in-flight call."
+  [workspace name f args meta']
+  (bump-per-fn-count! name)
+  (let [this     (mk-fn-tree :parent workspace :name name :args args :meta meta')
+        id       (:id this)
+        children (:children workspace)]
+    (swap! children
+           (fn [roots]
+             (let [roots' (conj roots this)
+                   over   (- (count roots') *record-limit*)]
+               (if (pos? over)
+                 (subvec roots' over)
+                 roots'))))
+    (let [value (binding [*trace-log-parent* this]
+                  (try
+                    (apply f args)
+                    (catch Throwable t
+                      (end-root-trace children id
+                                      {:throw (Throwable->map** t)
+                                       :ended-at (now)})
+                      (throw t))))]
+      (end-root-trace children id
+                      {:return value
+                       :ended-at (now)})
+      value)))
+
 (defn record-fn-call
   [parent name f args meta']
   (bump-per-fn-count! name)
@@ -218,6 +274,9 @@
         (cond
           (not (sample-root?))
           (run-suppressed f args)
+
+          *evict-old-calls*
+          (record-root-call-evicting workspace name f args meta')
 
           (>= (count @(:children workspace)) *record-limit*)
           (do (warn-record-limit!)

--- a/test/sayid/core_test.clj
+++ b/test/sayid/core_test.clj
@@ -332,6 +332,18 @@
       (t/is (= 2 (-> (sd/ws-deref!) :children count))
             "only *per-fn-limit* calls of func1 are recorded, the rest run untraced"))))
 
+(t/deftest evict-old-calls-keeps-the-most-recent
+  (t/testing "*evict-old-calls* keeps the last *record-limit* root calls"
+    (binding [sdt/*record-limit* 3
+              sdt/*evict-old-calls* true]
+      (sd/ws-add-trace-ns! ns1)
+      (doseq [x [:a :b :c :d :e]] (ns1/func1 x))
+      (let [roots (:children (sd/ws-deref!))]
+        (t/testing "; only the last three are kept"
+          (t/is (= 3 (count roots))))
+        (t/testing "; and they're the most recent, in order"
+          (t/is (= [[:c] [:d] [:e]] (map :args roots))))))))
+
 (t/deftest suppressed-root-with-inner-trace-is-skipped-cleanly
   (t/testing "a skipped root that calls an inner-traced fn records nothing, cleanly"
     ;; Regression guard for the suppression fix: without it, the skipped root's


### PR DESCRIPTION
The final recording bound, closing out initiative 2. `sayid.trace/*evict-old-calls*` (default false) switches `*record-limit*` from keep-the-first-N to a keep-the-last-N ring: at the limit, the oldest top-level call is evicted rather than new ones dropped. That's what you want when the failure is at the *end* of a long run and you care about the calls just before it.

The trap I flagged in the investigation, handled: `end-trace` updates a node by position, and eviction shifts positions, so an in-flight call's index goes stale the moment root calls overlap (concurrent tests, a parallel runner, traced code spawning threads). The eviction path ends the **root** by node **id** instead - nested end-traces stay positional and fast - so it's correct under concurrency, and an already-evicted root's end is a harmless no-op.

Test keeps the last 3 of 5 calls and checks they're the most recent, in order. Full Clojure suite (51 tests) and clj-kondo green.

With this, all of initiative 2's bounds are in: breadth (`*record-limit*`), depth (`*max-trace-depth*`), sampling (`*sample-rate*`), per-fn (`*per-fn-limit*`), and keep-last-N eviction - plus the bounded value serialization from #115.