### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## [0.5.0] - 2026-07-01
 
 * [#119](https://github.com/clojure-emacs/sayid/pull/119): Add `sayid.trace/*evict-old-calls*` (default false), which switches the record limit from keeping the first N top-level calls to a keep-the-last-N ring, evicting the oldest.
 * [#118](https://github.com/clojure-emacs/sayid/pull/118): Add `sayid.trace/*per-fn-limit*` (default unbounded), which caps how many calls of any single function are recorded, so one hot function can't crowd out the rest of the recording.

--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ provides a very flexible Sayid API. Its ops are documented in
 
 Add this to the dependencies in your project.clj or lein profiles.clj:
 
-    [mx.cider/sayid "0.4.0"]
+    [mx.cider/sayid "0.5.0"]
 
 To use the bundled nREPL middleware, you'll want to include Sayid as a
 plug-in. Here's an example of a bare-bones profiles.clj that works for
 me:
 
 ```clojure
-{:user {:plugins [[mx.cider/sayid "0.4.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.5.0"]]}}
 ```
 
 ### Clojure CLI - deps.edn
@@ -94,7 +94,7 @@ tools.deps config directory (often `$HOME/.clojure`).
 
 ```clojure
 {:deps
-  {mx.cider/sayid {:mvn/version "0.4.0"}}}
+  {mx.cider/sayid {:mvn/version "0.5.0"}}}
 ```
 
 ### Emacs Integration
@@ -119,7 +119,7 @@ that works for me:
 
 ```clojure
 {:user {:plugins [[cider/cider-nrepl "0.59.0"]
-                  [mx.cider/sayid "0.4.0"]]
+                  [mx.cider/sayid "0.5.0"]]
         :dependencies [[nrepl/nrepl "1.3.1"]]}}
 ```
 

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -11,7 +11,7 @@ This document is the reference for that wire API.
 With Leiningen, add Sayid as a plugin (it registers the middleware automatically):
 
 ```clojure
-{:user {:plugins [[mx.cider/sayid "0.4.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.5.0"]]}}
 ```
 
 Or add the middleware explicitly when you start the server, e.g. with the
@@ -259,7 +259,7 @@ Remove all traces and clear the recorded calls. Takes no params. Replies
 
 ### `sayid-version`
 
-Replies with the Sayid version string (e.g. `"0.4.0"`).
+Replies with the Sayid version string (e.g. `"0.5.0"`).
 
 ### `sayid-get-trace-count`
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mx.cider/sayid "0.4.0"
+(defproject mx.cider/sayid "0.5.0"
   :description "Sayid is a library for debugging and profiling clojure code."
   :url "https://github.com/clojure-emacs/sayid"
   :scm {:name "git" :url "https://github.com/clojure-emacs/sayid"}

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -4,7 +4,7 @@
 
 ;; Author: Bill Piel <bill@billpiel.com>
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
-;; Version: 0.4.0
+;; Version: 0.5.0
 ;; URL: https://github.com/clojure-emacs/sayid
 ;; Package-Requires: ((emacs "28") (cider "1.23"))
 ;; Keywords: clojure, cider, debugger
@@ -51,11 +51,11 @@ The injected dependencies are most likely nREPL middlewares."
   :type 'boolean)
 
 (defconst sayid-version
-  "0.4.0"
+  "0.5.0"
   "The current version of sayid.")
 
 (defconst sayid-injected-plugin-version
-  "0.4.0"
+  "0.5.0"
   "The version of the sayid Lein plugin to be automatically injected.")
 
 (defface sayid-int-face '((t :inherit default))

--- a/src/sayid/core.clj
+++ b/src/sayid/core.clj
@@ -14,7 +14,7 @@
 
 (def version
   "The current version of sayid as a string."
-  "0.4.0")
+  "0.5.0")
 
 (def workspace
   "The active workspace. Used by default in any function prefixed `ws-`

--- a/src/sayid/plugin.clj
+++ b/src/sayid/plugin.clj
@@ -2,7 +2,7 @@
 
 (def version
   "The current version of sayid as a string."
-  "0.4.0")
+  "0.5.0")
 
 (defn middleware
   [project]


### PR DESCRIPTION
Cuts 0.5.0. Bumps the version everywhere `doc/releasing.md` lists and dates the changelog.

The headline of 0.5.0 is **initiative 2 - bounding the recording** (the old adoption blocker): a full, tunable toolkit of recording bounds - `*record-limit*` (breadth), `*max-trace-depth*` (depth), `*sample-rate*` (1-in-N), `*per-fn-limit*`, and `*evict-old-calls*` (keep-last-N) - plus bounded value serialization so an infinite seq can't hang the serializer. Also brings back trace management (enable/disable/remove/inner/outer) in the traced-functions tree.

Deploy (dual-coordinate Clojars) and tagging happen after this merges.