### PR TITLE
Add tools.analyzer.jvm inner-tracing scaffold behind a flag

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,9 @@
   ;; pulled in by our dependencies to avoid version conflicts.
   :dependencies [[tamarin "0.1.2" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.reader "1.6.0" :exclusions [org.clojure/clojure]]
-                 [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure]]]
+                 [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure]]
+                 [org.clojure/tools.analyzer.jvm "1.3.2" :exclusions [org.clojure/clojure
+                                                                      org.clojure/tools.reader]]]
 
   :aot [sayid.sayid-multifn]
 

--- a/src/sayid/inner_ast.clj
+++ b/src/sayid/inner_ast.clj
@@ -1,0 +1,54 @@
+(ns sayid.inner-ast
+  "Inner-tracing instrumenter built on `tools.analyzer.jvm`.
+
+  Instead of re-reading source and hand-rewriting raw forms (see `sayid.inner-trace`),
+  this analyzes a traced function's source into a typed AST and re-emits it.  All
+  macros and special forms are already expanded and enumerable in the AST, so the
+  instrumenter needs no per-macro special-casing.
+
+  This namespace is the scaffold: `instrument` is currently the identity transform
+  (emit the analyzed form unchanged), which exercises the analyze -> emit -> eval
+  -> redefine pipeline end to end.  The capturing walk lands in a follow-up, at
+  which point this becomes the real inner tracer."
+  (:require [clojure.tools.analyzer.jvm :as ana]
+            [clojure.tools.analyzer.passes.jvm.emit-form :as emit]
+            [sayid.util.other :as util]
+            [sayid.util.sym :as sym]
+            [sayid.util.source :as src]))
+
+(defn defn->fn-form
+  "Pull the `(fn* ...)` form out of a `defn` source form, macroexpanded in NS-SYM.
+  Mirrors what the legacy instrumenter extracts, so both share a source shape."
+  [src ns-sym]
+  (let [expanded (sym/macroexpand-in-ns ns-sym src)]
+    (if (and (seq? expanded)
+             (= 'def (first expanded))
+             (symbol? (second expanded)))
+      (last expanded)
+      (throw (ex-info "Sayid inner tracing expected a defn form"
+                      {:form src :expanded expanded})))))
+
+(defn analyze-in-ns
+  "Analyze FORM to a `tools.analyzer.jvm` AST as if it were read in NS-SYM, so the
+  function's free symbols resolve against the right namespace."
+  [ns-sym form]
+  (binding [*ns* (create-ns ns-sym)]
+    (ana/analyze form (ana/empty-env))))
+
+(defn instrument
+  "Turn a function AST into an evaluable fn form.  For now this is the identity
+  transform - emit the hygienic form unchanged - so locals keep their meaning and
+  the function behaves exactly as before.  The capturing walk replaces this."
+  [ast]
+  (emit/emit-hygienic-form ast))
+
+(defn inner-tracer
+  "Produce an inner-traced replacement for the function named by :qual-sym by
+  analyzing its source, instrumenting the AST, and evaluating the result back in
+  its namespace."
+  [{:keys [qual-sym ns']}]
+  (let [ns-sym  (util/->symbol ns')
+        source  (-> qual-sym symbol src/hunt-down-source)
+        fn-form (defn->fn-form source ns-sym)
+        ast     (analyze-in-ns ns-sym fn-form)]
+    (sym/eval-in-ns ns-sym (instrument ast))))

--- a/src/sayid/inner_trace.clj
+++ b/src/sayid/inner_trace.clj
@@ -3,6 +3,7 @@
             [sayid.util.sym :as sym]
             [sayid.util.source :as src]
             [sayid.trace :as trace]
+            [sayid.inner-ast :as inner-ast]
             clojure.pprint
             clojure.set
             clojure.string
@@ -812,10 +813,20 @@
            (throw e)))))
 
 
+(def ^:dynamic *inner-trace-impl*
+  "Which instrumenter builds an inner-traced function:
+   :legacy - the original raw-form rewriter in this namespace (default)
+   :ast    - the `tools.analyzer.jvm`-based instrumenter in `sayid.inner-ast`
+
+  A migration seam: the AST instrumenter is being grown to parity behind this
+  flag before it becomes the default."
+  :legacy)
+
 (defn ^{::trace/trace-type :inner-fn} composed-tracer-fn
   [m _]
-  (->> m
-       inner-tracer
+  (->> (case *inner-trace-impl*
+         :ast (inner-ast/inner-tracer m)
+         (inner-tracer m))
        (trace/shallow-tracer m)))
 
 (defmethod trace/trace* :inner-fn

--- a/test/sayid/inner_trace_test.clj
+++ b/test/sayid/inner_trace_test.clj
@@ -8,6 +8,7 @@
   (:require [clojure.test :as t]
             [sayid.core :as sd]
             [sayid.trace :as sdt]
+            [sayid.inner-trace :as it]
             [sayid.inner-corpus :as c]
             [sayid.test-utils :as t-utils]))
 
@@ -147,6 +148,18 @@
                         (t/is (= 5 (c/multi 2 3))))]
     ;; the 1-arg body delegates to the 2-arg one; the (+ a b) shows up
     (t/is (contains? (forms forest) '(+ a b)))))
+
+(t/deftest ast-impl-identity-pipeline
+  ;; Phase 0 scaffold: the AST instrumenter currently re-emits the fn unchanged.
+  ;; This proves the analyze -> emit -> eval -> redefine pipeline works in-repo:
+  ;; the traced fn still returns the right value and its call is still recorded,
+  ;; but no inner nodes appear yet (that's the next phase).
+  (binding [it/*inner-trace-impl* :ast]
+    (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)
+                          (t/is (= 26 (c/arith 6 7))))]
+      (t/is (= 1 (count forest)))
+      (t/is (= 26 (:return (first forest))))
+      (t/is (= [] (:children (first forest))) "scaffold captures no inner nodes yet"))))
 
 (t/deftest nested-inner-and-outer
   (let [forest (capture (do (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)


### PR DESCRIPTION
Phase 0 of rebuilding inner tracing on the analyzed AST. Adds the `tools.analyzer.jvm` dependency and a new `sayid.inner-ast` namespace, dispatched behind `sayid.inner-trace/*inner-trace-impl*` (`:legacy` default, `:ast` opt-in). The legacy rewriter is untouched and stays the default.

The scaffold's instrumenter is intentionally the **identity transform**: analyze the fn's source into a typed AST and re-emit the hygienic form unchanged. The point is to prove the analyze -> emit -> eval -> redefine pipeline works in-repo across the whole JDK/Clojure matrix, isolated from the capturing walk that comes next - so if the analyzer dependency misbehaves anywhere (JDK 8, Clojure 1.10), we find out in a tiny PR rather than tangled up with the instrumentation logic.

A spike had already shown `:raw-forms` recovers surface syntax (`(+ a b)`, not the lowered `clojure.lang.Numbers/add`) and `:env` context flags tail position - the two things the legacy code reinvents by hand. A test drives the `:ast` path here: the traced fn still returns the right value and its call is still recorded, with no inner nodes yet.

No behaviour change by default.