### PR TITLE
Implement the AST-based inner-tracing instrumenter

### DIFF
--- a/src/sayid/inner_ast.clj
+++ b/src/sayid/inner_ast.clj
@@ -2,23 +2,145 @@
   "Inner-tracing instrumenter built on `tools.analyzer.jvm`.
 
   Instead of re-reading source and hand-rewriting raw forms (see `sayid.inner-trace`),
-  this analyzes a traced function's source into a typed AST and re-emits it.  All
-  macros and special forms are already expanded and enumerable in the AST, so the
-  instrumenter needs no per-macro special-casing.
+  this analyzes a traced function's source into a typed AST and re-emits it with
+  capturing calls wrapped around its sub-expressions.  Because macros and special
+  forms are already expanded and enumerable in the AST, there's no per-macro
+  special-casing - the thing that made the legacy rewriter fragile.
 
-  This namespace is the scaffold: `instrument` is currently the identity transform
-  (emit the analyzed form unchanged), which exercises the analyze -> emit -> eval
-  -> redefine pipeline end to end.  The capturing walk lands in a follow-up, at
-  which point this becomes the real inner tracer."
+  Two facts the analyzer hands us for free do the heavy lifting the legacy code
+  reinvents by hand:
+   - `:raw-forms` recovers each node's *surface* syntax (`(+ a b)`, not the
+     lowered `clojure.lang.Numbers/add`), so captures show the user's code.
+   - `:env` marks tail position and `:op` marks `recur`, so we know exactly what
+     must not be wrapped to keep `recur` legal."
   (:require [clojure.tools.analyzer.jvm :as ana]
+            [clojure.tools.analyzer.ast :as ast]
             [clojure.tools.analyzer.passes.jvm.emit-form :as emit]
             [sayid.util.other :as util]
             [sayid.util.sym :as sym]
-            [sayid.util.source :as src]))
+            [sayid.util.source :as src]
+            [sayid.trace :as trace]))
+
+;;; ---- runtime ------------------------------------------------------------
+
+(def ^:dynamic *inner-children*
+  "The `:children` atom of the current inner-trace parent node, or nil when we're
+  not (yet) inside an inner-trace scope for this call."
+  nil)
+
+(defn inner-root-children
+  "The children atom the top-level captures of a traced call attach to: the outer
+  (shallow) trace node for this call.  Nil when there's nothing to attach to -
+  recording suppressed, or no outer parent - in which case captures pass through."
+  []
+  (when (and (not trace/*suppress-recording*)
+             trace/*trace-log-parent*)
+    (:children trace/*trace-log-parent*)))
+
+(defn capture
+  "Record the sub-expression FORM (its surface syntax) named NM while evaluating
+  THUNK, then return THUNK's value.  Attaches a node under the current parent and
+  binds itself as the parent for nested captures.  Re-raises any exception after
+  recording it, so the traced code's control flow (try/catch, and callers) is
+  preserved exactly."
+  [form nm thunk]
+  (let [children (or *inner-children* (inner-root-children))]
+    (if (nil? children)
+      (thunk)
+      (let [node (atom (assoc (trace/mk-tree :id-prefix "in")
+                              :name nm
+                              :form form
+                              :started-at (trace/now)))]
+        (swap! children conj node)
+        (binding [*inner-children* (:children @node)]
+          (try
+            (let [v (thunk)]
+              (swap! node assoc :return v :ended-at (trace/now))
+              v)
+            (catch Throwable t
+              (swap! node assoc
+                     :throw (trace/Throwable->map** t)
+                     :ended-at (trace/now))
+              (throw t))))))))
+
+;;; ---- instrumentation ----------------------------------------------------
+
+(def ^:private wrappable-ops
+  "Call-like AST ops worth capturing.  Special forms (`if`/`let`/`do`/...) are
+  left as control flow and not captured as nodes themselves; their interesting
+  sub-expressions are captured where they occur."
+  #{:invoke :static-call :instance-call :protocol-invoke :keyword-invoke :new
+    :host-call :host-interop})
+
+(def ^:private lowered-ops
+  "Ops the analyzer lowers to interop, so their `:form` is the JVM form
+  (`clojure.lang.Numbers/add`) rather than the surface syntax.  For these the
+  pre-lowering surface lives in `:raw-forms`."
+  #{:static-call :instance-call :host-call :host-interop :new})
+
+(defn- unwrap-do
+  "Peel single-expression `(do x)` wrappers - the implicit `do` of a fn/branch
+  body attaches one around its return expression."
+  [form]
+  (if (and (seq? form) (= 'do (first form)) (= 2 (count form)))
+    (recur (second form))
+    form))
+
+(defn- surface-form
+  "The node's surface form: what the user wrote for this sub-expression.  For
+  lowered interop ops that's the last (most-expanded) raw form - `(+ a b)`, not
+  `(. clojure.lang.Numbers (add a b))`; for ordinary calls `:form` already is the
+  surface (`(reduce + 0 ...)`).  Trivial `(do x)` wrappers are peeled off."
+  [node]
+  (unwrap-do
+   (if (contains? lowered-ops (:op node))
+     (or (last (:raw-forms node)) (:form node))
+     (:form node))))
+
+(defn- node-name
+  [node]
+  (let [f (surface-form node)]
+    (if (seq? f) (first f) f)))
+
+(defn- contains-recur?
+  "True if NODE's subtree contains a `recur`.  Since `recur` is only legal in tail
+  position, any recur under a node sits on that node's tail path - so wrapping the
+  node (in a thunk) would relocate the recur out of its loop.  Skip those."
+  [node]
+  (boolean (some #(= :recur (:op %)) (ast/nodes node))))
+
+(defn- wrappable?
+  [node]
+  (and (contains? wrappable-ops (:op node))
+       (not (contains-recur? node))))
+
+(defn- wrap-node
+  "Replace a wrappable node with `(capture 'form 'name (fn* [] <node>))`,
+  re-analyzed in the node's own environment so its locals still resolve."
+  [node]
+  (if (wrappable? node)
+    (let [form (surface-form node)
+          nm   (node-name node)
+          sub  (emit/emit-form node)
+          wrapped (list `capture
+                        (list 'quote form)
+                        (list 'quote nm)
+                        (list 'fn* [] sub))]
+      (ana/analyze wrapped (:env node)))
+    node))
+
+(defn instrument
+  "Turn a function AST into an evaluable, instrumented fn form: wrap each
+  capturable sub-expression bottom-up, then emit.  Emission is non-hygienic so
+  the function's own (already-valid) local names are preserved consistently
+  between the wrappers and the code they wrap."
+  [ast]
+  (emit/emit-form (ast/postwalk ast wrap-node)))
+
+;;; ---- entry point --------------------------------------------------------
 
 (defn defn->fn-form
-  "Pull the `(fn* ...)` form out of a `defn` source form, macroexpanded in NS-SYM.
-  Mirrors what the legacy instrumenter extracts, so both share a source shape."
+  "Pull the `(fn* ...)` form out of a `defn` source form, macroexpanded in NS-SYM."
   [src ns-sym]
   (let [expanded (sym/macroexpand-in-ns ns-sym src)]
     (if (and (seq? expanded)
@@ -29,18 +151,10 @@
                       {:form src :expanded expanded})))))
 
 (defn analyze-in-ns
-  "Analyze FORM to a `tools.analyzer.jvm` AST as if it were read in NS-SYM, so the
-  function's free symbols resolve against the right namespace."
+  "Analyze FORM to a `tools.analyzer.jvm` AST as if read in NS-SYM."
   [ns-sym form]
   (binding [*ns* (create-ns ns-sym)]
     (ana/analyze form (ana/empty-env))))
-
-(defn instrument
-  "Turn a function AST into an evaluable fn form.  For now this is the identity
-  transform - emit the hygienic form unchanged - so locals keep their meaning and
-  the function behaves exactly as before.  The capturing walk replaces this."
-  [ast]
-  (emit/emit-hygienic-form ast))
 
 (defn inner-tracer
   "Produce an inner-traced replacement for the function named by :qual-sym by

--- a/test/sayid/inner_ast_test.clj
+++ b/test/sayid/inner_ast_test.clj
@@ -1,0 +1,121 @@
+(ns sayid.inner-ast-test
+  "Drives the tools.analyzer.jvm-based inner-tracing instrumenter (the `:ast`
+  impl).  Asserts the invariants that matter - the traced fn's own value, the
+  surface form and value of each captured sub-expression, and exception
+  transparency - rather than the legacy impl's exact node taxonomy."
+  (:require [clojure.test :as t]
+            [sayid.core :as sd]
+            [sayid.trace :as sdt]
+            [sayid.inner-trace :as it]
+            [sayid.inner-corpus :as c]
+            [sayid.test-utils :as t-utils]))
+
+(defn- fixture [f]
+  (with-out-str (sd/ws-reset!))
+  (binding [it/*inner-trace-impl* :ast]
+    (with-redefs [sdt/now (t-utils/mock-now-fn)
+                  gensym (t-utils/mock-gensym-fn)]
+      (f)
+      (with-out-str (sd/ws-reset!)))))
+
+(t/use-fixtures :each fixture)
+
+(defn normalize [node]
+  {:form (:form node)
+   :name (:name node)
+   :return (:return node)
+   :threw? (boolean (:throw node))
+   :children (mapv normalize (:children node))})
+
+(defmacro capture [add-form & body]
+  `(do (with-out-str (sd/ws-reset!))
+       ~add-form
+       ~@body
+       (->> (sd/ws-deref!) :children (mapv normalize))))
+
+(defn nodes [forest]
+  (mapcat #(tree-seq (constantly true) :children %) forest))
+
+(defn forms [forest]
+  (set (map :form (nodes forest))))
+
+(defn returns-for [forest form]
+  (->> (nodes forest) (filter #(= form (:form %))) (map :return)))
+
+(defn return-for [forest form]
+  (let [rs (returns-for forest form)]
+    (t/is (= 1 (count rs)) (str "expected one capture of " (pr-str form)))
+    (first rs)))
+
+;;; ---- corpus under the AST impl -----------------------------------------
+
+(t/deftest arith-let-if
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)
+                        (t/is (= 26 (c/arith 6 7))))]
+    (t/is (= 13 (return-for forest '(+ a b))))
+    (t/is (= true (return-for forest '(> s 10))))
+    (t/is (= 26 (return-for forest '(* s 2))))))
+
+(t/deftest threading-macro
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/threaded)
+                        (t/is (= 6 (c/threaded [1 2 3 4]))))]
+    (t/is (= '(2 3 4 5) (return-for forest '(map inc xs))))
+    (t/is (= '(2 4) (return-for forest '(filter even? (map inc xs)))))
+    (t/is (= 6 (return-for forest '(reduce + 0 (filter even? (map inc xs))))))))
+
+(t/deftest cond-macro
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/branchy)
+                        (t/is (= :neg (c/branchy -3))))]
+    (t/is (= true (return-for forest '(neg? n))))))
+
+(t/deftest when-macro
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/whenny)
+                        (t/is (= 6 (c/whenny 5))))]
+    (t/is (= true (return-for forest '(pos? n))))
+    (t/is (= 6 (return-for forest '(inc n))))))
+
+(t/deftest loop-recur
+  ;; The AST impl doesn't synthesize loop/recur pseudo-nodes (that hand-rolled
+  ;; machinery is what made the legacy impl fragile).  It captures the real
+  ;; sub-expressions - the test and the recur arguments - and, crucially, the
+  ;; loop still computes correctly.
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/looped)
+                        (t/is (= 6 (c/looped 4))))]
+    (t/is (= [true true true true false] (returns-for forest '(< i n))))
+    (t/is (= [1 2 3 4] (returns-for forest '(inc i))))
+    (t/is (= [0 1 3 6] (returns-for forest '(+ acc i))))))
+
+(t/deftest letfn-body
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/letfned)
+                        (t/is (= 8 (c/letfned 3))))]
+    (t/is (= 4 (return-for forest '(inc a))))))
+
+(t/deftest case-macro
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/cased)
+                        (t/is (= 2 (c/cased :b))))]
+    (t/is (some #(= 2 (:return %)) (nodes forest)))))
+
+(t/deftest try-catch-is-exception-transparent
+  ;; The headline correctness win over the legacy impl: an inner-traced try/catch
+  ;; still sees the exception, so the catch fires and the value is right.
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/caught)
+                        (t/is (= :div-by-zero (c/caught 0))))]
+    (t/testing "the throwing sub-expression is recorded as having thrown"
+      (t/is (some #(and (= '(/ 10 n) (:form %)) (:threw? %)) (nodes forest))))))
+
+(t/deftest destructuring-args
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/destructured)
+                        (t/is (= 7 (c/destructured {:x 3 :y 4}))))]
+    (t/is (= 7 (return-for forest '(+ x y))))))
+
+(t/deftest multi-arity
+  (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/multi)
+                        (t/is (= 4 (c/multi 3)))
+                        (t/is (= 5 (c/multi 2 3))))]
+    (t/is (contains? (forms forest) '(+ a b)))))
+
+(t/deftest nested-inner-and-outer
+  (let [forest (capture (do (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)
+                            (sd/ws-add-inner-trace-fn! sayid.inner-corpus/threaded))
+                        (t/is (= 1 (c/nested-calls 1 2))))]
+    (t/is (contains? (forms forest) '(map inc xs)))))

--- a/test/sayid/inner_trace_test.clj
+++ b/test/sayid/inner_trace_test.clj
@@ -8,7 +8,6 @@
   (:require [clojure.test :as t]
             [sayid.core :as sd]
             [sayid.trace :as sdt]
-            [sayid.inner-trace :as it]
             [sayid.inner-corpus :as c]
             [sayid.test-utils :as t-utils]))
 
@@ -148,18 +147,6 @@
                         (t/is (= 5 (c/multi 2 3))))]
     ;; the 1-arg body delegates to the 2-arg one; the (+ a b) shows up
     (t/is (contains? (forms forest) '(+ a b)))))
-
-(t/deftest ast-impl-identity-pipeline
-  ;; Phase 0 scaffold: the AST instrumenter currently re-emits the fn unchanged.
-  ;; This proves the analyze -> emit -> eval -> redefine pipeline works in-repo:
-  ;; the traced fn still returns the right value and its call is still recorded,
-  ;; but no inner nodes appear yet (that's the next phase).
-  (binding [it/*inner-trace-impl* :ast]
-    (let [forest (capture (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)
-                          (t/is (= 26 (c/arith 6 7))))]
-      (t/is (= 1 (count forest)))
-      (t/is (= 26 (:return (first forest))))
-      (t/is (= [] (:children (first forest))) "scaffold captures no inner nodes yet"))))
 
 (t/deftest nested-inner-and-outer
   (let [forest (capture (do (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)


### PR DESCRIPTION
Phase 2 of the initiative-4 rewrite: the real `sayid.inner-ast` instrumenter, replacing the identity scaffold. Still opt-in behind `*inner-trace-impl* :ast` - legacy stays the default until it's proven at parity.

It walks the analyzed AST bottom-up, wraps each call-like sub-expression with a capture call, and emits the result to redefine the fn. Because macros and special forms are already expanded in the AST, there's **no per-macro special-casing** - the thing that made the legacy rewriter fragile and needed a bespoke patch for `letfn`.

Two analyzer facts do the heavy lifting the legacy code reinvents by hand:
- `:raw-forms` recovers each node's **surface syntax**, so captures show `(+ a b)`, not the lowered `clojure.lang.Numbers/add`. Picking the right raw form is op-aware (lowered interop reads `:raw-forms`, ordinary calls already carry the surface in `:form`), plus trivial `(do x)` body-wrappers get peeled.
- `recur` is only legal in tail position, so any node whose subtree contains a `recur` is left unwrapped; its non-recur sub-expressions (the test, the recur args) are still captured. No `lazy-recur`/`mk-recur-handler` gymnastics.

The runtime capture fn **self-initialises** its parent from the outer trace node, so the fn body needs no `binding` wrapper (which would knock `recur` out of tail position). It **re-raises after recording**, preserving control flow - which fixes the exception-transparency bug the corpus caught: an inner-traced `try/catch` now sees the exception and returns the caught value, instead of the legacy impl swallowing it and returning nil.

Driven by a full corpus under `:ast` (`sayid.inner-ast-test`): let/if, threading, cond/when/case, loop/recur, letfn, try/catch, destructuring, multi-arity, nested. No default behaviour change.