### PR TITLE
Make the AST inner-tracing instrumenter the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Rebuild inner tracing on `tools.analyzer.jvm` (`sayid.inner-ast`), working off the analyzed AST instead of re-reading source and rewriting raw forms. It's now the default; the legacy rewriter stays available for one release via `sayid.inner-trace/*inner-trace-impl*` (`:ast` / `:legacy`). Fixes inner-traced `try/catch` swallowing exceptions, and drops the per-macro special-casing.
+
 ## [0.5.0] - 2026-07-01
 
 * [#119](https://github.com/clojure-emacs/sayid/pull/119): Add `sayid.trace/*evict-old-calls*` (default false), which switches the record limit from keeping the first N top-level calls to a keep-the-last-N ring, evicting the oldest.

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -162,20 +162,34 @@ the least trustworthy part of an otherwise solid tool (and the `inner_trace3` it
 grew out of had been rewritten twice already).
 
 **Approach:**
-- Rebuild instrumentation on
-  [`tools.analyzer.jvm`](https://github.com/clojure/tools.analyzer.jvm) so it
-  works off the analyzed AST instead of raw forms. Walk the AST, wrap
-  sub-expressions with capture, emit instrumented code.
-- Keep the current rewriter behind a flag during migration and diff their captures
-  on a corpus of real namespaces (this is where initiative 2's snapshots help -
-  captures become comparable data).
+- *Done.* Rebuilt instrumentation on
+  [`tools.analyzer.jvm`](https://github.com/clojure/tools.analyzer.jvm) in
+  `sayid.inner-ast`: it walks the analyzed AST, wraps each call-like
+  sub-expression with a capture call, and emits the result. Macros and special
+  forms are already expanded in the AST, so there's no per-macro special-casing.
+  Two analyzer facts replace machinery the legacy code reinvents by hand -
+  `:raw-forms` recovers the surface syntax for display, and node context marks
+  tail position so `recur` is left legal. The runtime capture re-raises after
+  recording, so it's exception-transparent (an inner-traced `try/catch` now sees
+  the exception, which the legacy rewriter swallowed).
+- *Done.* Kept the legacy rewriter behind `sayid.inner-trace/*inner-trace-impl*`
+  and diffed both impls across a corpus (`sayid.inner-ast-test`,
+  `sayid.inner-diff-test`): instrumenting never changes a fn's result, and the
+  AST impl captures a superset of legacy's sub-expression values. The AST impl is
+  now the default; `:legacy` remains a fallback for one release.
+- *Still to do.* Delete the legacy rewriter and its disk-source/path-symbol
+  machinery once the AST impl has real mileage. On-demand tracing still needs the
+  source *form* (you can't analyze a compiled fn), so a genuinely source-less fn
+  still can't be inner-traced - that limit is inherent to the on-demand model, not
+  the rewriter, and would need compile-time instrumentation to lift.
 
 **Risks:** this is the largest single chunk and the highest-cleverness code in the
 project. It must preserve evaluation semantics exactly (no double-eval of
 side-effecting forms, correct `recur`/`loop`/`letfn` handling).
 
 **Done when:** inner tracing works on a corpus that breaks the current rewriter,
-with no special-case patches per macro.
+with no special-case patches per macro. *(Met: the AST impl handles the corpus
+uniformly and is the default; only removing the legacy code remains.)*
 
 ### 5. Position and extend
 

--- a/src/sayid/inner_trace.clj
+++ b/src/sayid/inner_trace.clj
@@ -815,12 +815,13 @@
 
 (def ^:dynamic *inner-trace-impl*
   "Which instrumenter builds an inner-traced function:
-   :legacy - the original raw-form rewriter in this namespace (default)
    :ast    - the `tools.analyzer.jvm`-based instrumenter in `sayid.inner-ast`
+             (default): works off the analyzed AST, so no per-macro special-casing
+   :legacy - the original raw-form rewriter in this namespace
 
-  A migration seam: the AST instrumenter is being grown to parity behind this
-  flag before it becomes the default."
-  :legacy)
+  The AST impl is the default; `:legacy` stays available for one release as a
+  fallback while it proves itself in the wild."
+  :ast)
 
 (defn ^{::trace/trace-type :inner-fn} composed-tracer-fn
   [m _]

--- a/test/sayid/inner_trace_test.clj
+++ b/test/sayid/inner_trace_test.clj
@@ -8,15 +8,21 @@
   (:require [clojure.test :as t]
             [sayid.core :as sd]
             [sayid.trace :as sdt]
+            [sayid.inner-trace :as it]
             [sayid.inner-corpus :as c]
             [sayid.test-utils :as t-utils]))
 
+;; This namespace characterizes the *legacy* rewriter specifically (its special
+;; form/macro tags and loop/recur pseudo-nodes), so it pins the impl to :legacy
+;; even though the default is now :ast.  The AST impl's behaviour lives in
+;; sayid.inner-ast-test.  When the legacy rewriter goes, so does this file.
 (defn- fixture [f]
   (with-out-str (sd/ws-reset!))
-  (with-redefs [sdt/now (t-utils/mock-now-fn)
-                gensym (t-utils/mock-gensym-fn)]
-    (f)
-    (with-out-str (sd/ws-reset!))))
+  (binding [it/*inner-trace-impl* :legacy]
+    (with-redefs [sdt/now (t-utils/mock-now-fn)
+                  gensym (t-utils/mock-gensym-fn)]
+      (f)
+      (with-out-str (sd/ws-reset!)))))
 
 (t/use-fixtures :each fixture)
 


### PR DESCRIPTION
Phase 4: flip `sayid.inner-trace/*inner-trace-impl*` to `:ast`, making the tools.analyzer.jvm instrumenter the default. The legacy raw-form rewriter stays available as `:legacy` for one release, in case something in the wild trips the new one.

The legacy characterization suite (`sayid.inner-trace-test`) now pins itself to `:legacy` - it asserts that impl's specific node taxonomy (special-form/macro tags, loop/recur pseudo-nodes), which the AST impl intentionally doesn't reproduce. The AST impl's behaviour is covered by `sayid.inner-ast-test` and the differential test, and it'll be deleted alongside the legacy code in the final phase.

Everything else runs green under the new default: the core inner-trace tests, the suppression path, and - checked end to end - `node->data` over an AST-produced inner trace serializes cleanly for the Emacs client.

Headline user-visible win: inner-traced `try/catch` is now exception-transparent (the legacy rewriter swallowed the exception and returned nil).
