### PR TITLE
Document the public API and prune the internal surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Sayid *(siy EED)* is an omniscient debugger and profiler for Clojure. It extracts secrets from code at run-time.
 
+The name is a nod to Sayid Jarrah from [*Lost*](https://en.wikipedia.org/wiki/Sayid_Jarrah) - the show's resident interrogator, who was famously good at extracting secrets. Which is exactly what this tool does to your code, hence the tagline. And yes, the *siy EED* pronunciation above is the character's too, so you can say it with confidence.
+
 Sayid works by intercepting and recording the inputs and outputs of
 functions. It can even record function calls that occur inside of
 functions. The user can select which functions to trace. Functions can

--- a/src/sayid/core.clj
+++ b/src/sayid/core.clj
@@ -1,4 +1,8 @@
 (ns sayid.core
+  "Sayid's public API and engine hub: the functions you drive tracing with from a
+  REPL - add and remove traces, run your code, then deref, query, profile and view
+  the recorded call tree.  Most fns have short `w-*` aliases.  The other `sayid.*`
+  namespaces are its implementation."
   (:require clojure.pprint
             [sayid.trace :as trace]
             [sayid.inner-ast :as itrace]
@@ -27,7 +31,10 @@
   (atom nil))
 
 (def view (atom nil))
-(def ^:dynamic *view* so/*view*)
+(def ^:dynamic *view*
+  "The view (output filter) applied when rendering the active workspace; mirrors
+  `sayid.string-output/*view*`."
+  so/*view*)
 
 (def config
   "Configuration map. Indicates which namespaces should be used to shelf
@@ -62,7 +69,10 @@ user> (-> #'f1 meta :source)
 
 ;; === Workspace functions
 
-(defn ws-init! [& [quiet]]
+(defn ws-init!
+  "Ensure the active workspace is initialized and return its atom.  QUIET suppresses
+  the status message."
+  [& [quiet]]
   (#'ws/init! workspace quiet))
 
 (defn ws-get-active!
@@ -71,7 +81,7 @@ user> (-> #'f1 meta :source)
   @(ws-init! :quiet))
 (util/defalias w-ga! ws-get-active!)
 
-(defn ws-show-traced*
+(defn ^:no-doc ws-show-traced*
   [& [ws]]
   (-> ws
       (or (ws-get-active!))
@@ -113,7 +123,7 @@ user> (-> #'f1 meta :source)
   [] (#'ws/clear-log! (ws-init! :quiet)))
 (util/defalias w-cl! ws-clear-log!)
 
-(defn ws-add-trace-fn!*
+(defn ^:no-doc ws-add-trace-fn!*
   [fn-sym]
   (#'ws/add-trace-*! (ws-init! :quiet)
                      :fn
@@ -231,6 +241,8 @@ user> (-> #'f1 meta :source)
 (util/defalias w-drf! ws-deref!)
 
 (defn ws-view!
+  "The active workspace (or W) filtered through the current view - i.e. the tree as
+  the renderers see it."
   [& [w]]
   (let [w' (or w
                (ws-deref!))]
@@ -389,6 +401,8 @@ user> (-> #'f1 meta :source)
                                  (meta v)))))))
 
 (defmacro with-this-view
+  "Evaluate BODY with VIEW' (or the current default view) in effect as the active
+  view."
   ([view' & body]
    `(let [v# (or ~view'
                  so/*view*)]
@@ -421,12 +435,15 @@ user> (-> #'f1 meta :source)
 (util/defalias w-pr ws-print)
 
 (defn rec-print
+  "Print the recording REC (or the active recording) as a tree."
   [& [rec]]
   (#'so/print-tree (or rec
                        @recording)))
 (util/defalias r-pr rec-print)
 
 (defn set-view!
+  "Set the active view (output filter) to VIEW', or back to the default when called
+  with no argument."
   [& [view']]
   (reset! view view'))
 
@@ -493,7 +510,7 @@ user> (-> #'f1 meta :source)
           %)
        form))
 
-(defn ws-query*
+(defn ^:no-doc ws-query*
   [& query]
   (apply #'q/q
          (ws-view!)
@@ -579,7 +596,7 @@ user> (-> #'f1 meta :source)
 
 ;; === TEMP
 
-(defn mk-src-pos-query-fn
+(defn- mk-src-pos-query-fn
   [file line]
   (fn [{:keys [src-pos]}]
     (and (= (:file src-pos) file)
@@ -587,6 +604,7 @@ user> (-> #'f1 meta :source)
          (>= (:end-line src-pos) line))))
 
 (defn ws-query-by-file-line
+  "Print the recorded calls whose source spans LINE in FILE."
   [file line]
   (println)
   (trees-print (ws-query* [(mk-src-pos-query-fn file line)]))
@@ -594,6 +612,8 @@ user> (-> #'f1 meta :source)
 
 ;; used only by middleware
 (defn ws-query-by-file-pos
+  "Query the active workspace for the calls at FILE/LINE, matched by source
+  position.  Used by the nREPL middleware."
   [file line]
   (ws-query* [:id (q/get-ids-from-file-pos (ws-view!)
                                            file

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -1,4 +1,8 @@
 (ns sayid.nrepl-middleware
+  "The nREPL wire protocol.  `wrap-sayid` registers Sayid's nREPL ops - trace
+  management, queries, and the data ops that hand the recorded call tree to editor
+  clients as plain data (see doc/nrepl-api.md) - by collecting the `^:nrepl`-tagged
+  vars in this namespace."
   (:require
    [clojure.stacktrace :as st]
    clojure.string
@@ -22,25 +26,16 @@
 (def views (atom {}))
 (def selected-view (atom nil))
 
-
-(defn try-find-ns-root
+(defn- try-find-ns-root
   [ns-sym]
   (let [depth (some-> ns-sym str (clojure.string/split #"\.") count)]
     (util/$- some-> ns-sym ns-interns vals first meta :file (clojure.string/split #"/") (drop-last depth $) (clojure.string/join "/" $))))
 
-(defn find-all-ns-roots
+(defn- find-all-ns-roots
   []
   (some->> (all-ns) (map str) (map symbol) (map try-find-ns-root) distinct (remove empty?)))
 
-
-(defn register-view!
-  [name view]
-  (swap! views
-         assoc
-         name
-         view))
-
-(defn query*
+(defn- query*
   [& args]
   (if args
     (assoc (apply sd/ws-query*
@@ -51,12 +46,12 @@
            ::query-args
            nil)))
 
-(defn query-tree->trio
+(defn- query-tree->trio
   [tree]
   (conj (vec (so/tree->text-prop-pair tree))
         (-> tree ::query-args pr-str)))
 
-(defn clj->nrepl*
+(defn- clj->nrepl*
   [v]
   (cond (coll? v) (list* v)
         (number? v) v
@@ -70,12 +65,12 @@
   (clojure.walk/prewalk clj->nrepl*
                         frm))
 
-(defn send-status-done
+(defn- send-status-done
   [msg]
   (t/send (:transport msg)
           (response-for msg :status :done)))
 
-(defn reply:clj->nrepl
+(defn- reply:clj->nrepl
   [msg out]
   (try (t/send (:transport msg)
                (response-for msg
@@ -85,7 +80,7 @@
          (println e)))
   (send-status-done msg))
 
-(defn reply:data
+(defn- reply:data
   "Reply with OUT sent as-is - no `clj->nrepl` flattening - and end the op.  For
   the data ops, whose shapes are already built to round-trip over bencode."
   [msg out]
@@ -93,7 +88,7 @@
           (response-for msg :value out))
   (send-status-done msg))
 
-(defn reply:error
+(defn- reply:error
   "Reply to MSG with a CIDER-renderable error response for EX and end the op.
 Mirrors the `:err'/`:ex' plus `:error'/`:done' status convention used by
 cider-nrepl, so the client surfaces the failure instead of silently getting
@@ -105,7 +100,7 @@ no value."
                         :ex (str (class ex))
                         :err (with-out-str (st/print-cause-trace ex)))))
 
-(defn find-ns-sym
+(defn- find-ns-sym
   [file]
   (some->> file
            slurp
@@ -113,7 +108,7 @@ no value."
            second
            symbol))
 
-(defn get-top-form-at-pos-in-source
+(defn- get-top-form-at-pos-in-source
   [file line source]
   (let [rdr (rts/source-logging-push-back-reader source
                                                  (count source)
@@ -127,11 +122,11 @@ no value."
           (> (:line m) line) nil
           :else (recur rdr-iter))))))
 
-(defn get-meta-at-pos-in-source
+(defn- get-meta-at-pos-in-source
   [file line source]
   (meta (get-top-form-at-pos-in-source file line source)))
 
-(defn pos-inside-line-column?
+(defn- pos-inside-line-column?
   [pos-line pos-column start-line end-line start-col end-col]
   (if (= start-line pos-line end-line)
     (<= start-col pos-column end-col)
@@ -141,7 +136,7 @@ no value."
              (< pos-column end-col))
         (< start-line pos-line end-line))))
 
-(defn get-sym-at-pos-in-source
+(defn- get-sym-at-pos-in-source
   [file pos-line pos-column source]
   (let [tseq (tree-seq coll? seq (get-top-form-at-pos-in-source file pos-line source))
         inside? (fn [sym]
@@ -155,7 +150,7 @@ no value."
                                                end-column))))]
     (last (filter inside? tseq))))
 
-(defn parse-ns-name-from-source ;; TODO don't use this
+(defn- parse-ns-name-from-source ;; TODO don't use this
   [source]
   (second (re-find #"\(\s*ns\s+([\w$.*-]+)"
                    source)))
@@ -184,37 +179,6 @@ or nil when nothing resolves there."
     (when qual-sym
       ((fn-trace-actions action) qual-sym))
     (reply:clj->nrepl msg qual-sym)))
-
-(defn tree-contains-inner-trace?
-  [tree]
-  (->> tree
-       (tree-seq map? :children)
-       (filter #(contains? % :src-pos))
-       first
-       nil?
-       not))
-
-(defn query-ws-by-file-line-range
-  "Find the tree node that: is smallest or starts latest, contains line
-  and starts at or after start-line."
-  [file start-line line]
-  (let [ws (sd/ws-deref!)
-        ids (q/get-ids-from-file-line-range ws
-                                            file
-                                            (or start-line line)
-                                            line)]
-    (if-not (empty? ids)
-      (query* [:id ids])
-      nil)))
-
-(defn process-line-meta
-  [line-meta]
-  (mapv (fn [[n m]]
-          [n
-           (-> m
-               (update-in [:path] str)
-               (update-in [:header] #(when % 1)))])
-        line-meta))
 
 ;; ======================
 
@@ -252,7 +216,7 @@ or nil when nothing resolves there."
                     (so/audit->text-prop-pair (-> @sd/workspace :traced tr/audit-traces)
                                               ns)))
 
-(defn audit-fn->data
+(defn- audit-fn->data
   "Serialize one fn-info map from the traced audit to bencode data."
   [fn-info]
   (->> {"name"       (some-> (:name fn-info) str)
@@ -283,7 +247,7 @@ or nil when nothing resolves there."
                       (filterv #(= ns (get % "ns")) groups)
                       groups))))
 
-(defn count-traces
+(defn- count-traces
   [trace-audit]
   (+ (count  (for [v1 (-> trace-audit :ns vals)
                    v2 (vals v1)]
@@ -292,7 +256,7 @@ or nil when nothing resolves there."
                    v2 (vals v1)]
                v2))))
 
-(defn count-enabled-traces
+(defn- count-enabled-traces
   [trace-audit]
   (+ (count  (for [v1 (-> trace-audit :ns vals)
                    v2 (vals v1)
@@ -342,7 +306,7 @@ or nil when nothing resolves there."
                     (-> (sd/ws-query-by-file-pos file line)
                         so/tree->text-prop-pair)))
 
-(defn buf-query-tree
+(defn- buf-query-tree
   "Build and run a buffer query.  Q-VEC is the base query; MOD-STR an optional
   modifier like \"a\" (ancestors) or \"d3\" (descendants, depth 3).  Returns the
   result tree, which `query-tree->trio` renders or `query-tree->data` turns into
@@ -354,7 +318,7 @@ or nil when nothing resolves there."
         query (remove nil? [k n q-vec])]
     (apply query* query)))
 
-(defn sayid-buf-query
+(defn- sayid-buf-query
   [q-vec mod-str]
   (sd/with-view (query-tree->trio (buf-query-tree q-vec mod-str))))
 
@@ -364,7 +328,7 @@ or nil when nothing resolves there."
                     (sayid-buf-query [:id (keyword trace-id)]
                                      mod)))
 
-(def parent-name-or-name (some-fn :parent-name :name))
+(def ^:private parent-name-or-name (some-fn :parent-name :name))
 
 (defn ^:nrepl sayid-query-by-fn
   [{:keys [fn-name mod] :as msg}]
@@ -373,7 +337,7 @@ or nil when nothing resolves there."
                                          mod)))
 
 ;; this func is unfortunate
-(defn str-vec->arg-path
+(defn- str-vec->arg-path
   [[kw & idx]]
   (let [kw' (keyword kw)
         str->sym (fn [s] (if (string? s)
@@ -383,7 +347,7 @@ or nil when nothing resolves there."
 
 ;; ===== gen-instance-expr helpers
 
-(defn find-arg-list-by-length
+(defn- find-arg-list-by-length
   [n [first-list & rest-lists]]
   (let [cfl (count first-list)]
     (cond (nil? first-list) nil
@@ -395,7 +359,7 @@ or nil when nothing resolves there."
 
           :else (recur n rest-lists))))
 
-(defn get-args-sym-template
+(defn- get-args-sym-template
   [arglist]
   (let [convert-non-syms (fn [v] (if (symbol? v)
                                    v
@@ -405,7 +369,7 @@ or nil when nothing resolves there."
              (map convert-non-syms)
              (concat $ (repeat (last $))))))
 
-(defn find-available-sym
+(defn- find-available-sym
   [ns-sym prefix & [init-taken]]
   (let [taken (set (or init-taken
                        (-> ns-sym
@@ -419,15 +383,14 @@ or nil when nothing resolves there."
           candidate
           (recur (inc n)))))))
 
-(defn lazy-find-available-sym
+(defn- lazy-find-available-sym
   [prefix-seq init-taken]
   (let [next (find-available-sym nil (first prefix-seq) init-taken)]
     (lazy-cat [next]
               (lazy-find-available-sym (rest prefix-seq)
                                        (conj init-taken next)))))
 
-
-(defn mk-avail-sym-lazy-seq
+(defn- mk-avail-sym-lazy-seq
   [n arglists]
   (lazy-find-available-sym (get-args-sym-template (find-arg-list-by-length n
                                                                            arglists))
@@ -439,7 +402,7 @@ or nil when nothing resolves there."
 
 ;; END ===== gen-instance-expr helpers
 
-(defn gen-instance-expr
+(defn- gen-instance-expr
   [tree]
   (let [arg-count (-> tree :args count)
         arglists (-> tree :meta :arglists)
@@ -555,7 +518,7 @@ or nil when nothing resolves there."
   "`*print-level*` applied when serializing captured values in the data ops."
   10)
 
-(defn pr-value
+(defn- pr-value
   "`pr-str` a captured value with the data-op print bounds applied, so an
   arbitrarily large or lazy/infinite value can't blow up the wire payload or hang
   the serializer."
@@ -564,7 +527,7 @@ or nil when nothing resolves there."
             *print-level* *value-print-level*]
     (pr-str v)))
 
-(defn throw->data
+(defn- throw->data
   "Trim a captured `:throw` (a `Throwable->map`) to the bencode-friendly bits a
   client needs: the message, the exception class, and any ex-data.  The full
   stack trace stays out of the wire shape."
@@ -614,20 +577,20 @@ or nil when nothing resolves there."
   [msg]
   (reply:data msg (mapv node->data (:children (sd/ws-deref!)))))
 
-(defn query-tree->data
+(defn- query-tree->data
   "The data counterpart of `query-tree->trio`: the tree's matched calls as a list
   of `node->data` maps."
   [tree]
   (mapv node->data (:children tree)))
 
-(defn magic-recusive-eval
+(defn- magic-recusive-eval
   "Lets us send vars to nrepl client and back. Madness."
   [frm]
   (cond (vector? frm) (mapv magic-recusive-eval frm)
         (seq? frm) (eval frm)
         :else frm))
 
-(defn run-query
+(defn- run-query
   "Parse a printed QUERY form (a string), eval any embedded vars via
   `magic-recusive-eval`, and run it.  Returns the result tree."
   [query]
@@ -679,7 +642,6 @@ or nil when nothing resolves there."
         (catch Throwable e
           (reply:error msg e)))
       (handler msg))))
-
 
 (set-descriptor! #'wrap-sayid
                  {:handles (zipmap (keys sayid-nrepl-ops)

--- a/src/sayid/profiling.clj
+++ b/src/sayid/profiling.clj
@@ -1,25 +1,27 @@
 (ns sayid.profiling
+  "Profiling: rolling per-function timing up from a recorded call tree - call
+  counts and durations grouped by function - into a report."
   (:require [sayid.trace :as tr]
             [sayid.recording :as rec]
             [sayid.util.other :as util]
             clojure.set
             [clojure.walk :as w]))
 
-(defn merge-profile-values
+(defn- merge-profile-values
   [a b]
   ((cond (number? a) +
          (set? a) clojure.set/union
          :default (throw (Exception. (format "Cant' merge this: '%s'" a))))
    a b))
 
-(def merge-profiles
+(def ^:private merge-profiles
   (memoize
    (fn [& rest]
      (apply merge-with
             #(merge-with merge-profile-values % %2)
             rest))))
 
-(defn finalize-profiles
+(defn- finalize-profiles
   [fn-ms]
   (util/apply-to-map-vals (fn [metrics]
                             (let [arg-cardinality (-> metrics :arg-set count)
@@ -42,7 +44,7 @@
                                                               repeat-arg-pct)))))
                           fn-ms))
 
-(defn get-profile
+(defn- get-profile
   [tree]
   (let [{{:keys [gross-time net-time arg-set]} :profiling
          name :name
@@ -59,7 +61,7 @@
                   children))
       entry)))
 
-(defn hash-safe
+(defn- hash-safe
   [x]
   (hash (w/prewalk (fn [v]
                      (if (seq? v)
@@ -67,15 +69,14 @@
                        v))
                    x)))
 
-(defn mk-arg-hash-set
+(defn- mk-arg-hash-set
   [tree]
   (->> tree
        :args
        (map hash-safe)
        set))
 
-
-(defn add-durations-to-tree
+(defn- add-durations-to-tree
   [tree]
   (let [gross-time (->> tree
                         ((juxt :ended-at :started-at))
@@ -106,9 +107,3 @@
         (apply merge-profiles)
         finalize-profiles
         (assoc tree' :profile))))
-
-(defn get-report
-  [tree])
-
-(defn print-report
-  [tree])

--- a/src/sayid/query.clj
+++ b/src/sayid/query.clj
@@ -1,4 +1,7 @@
 (ns sayid.query
+  "The query DSL: a small zipper-based language for selecting nodes out of a
+  recorded call tree - by function name, call id, tag, source position or
+  ancestry - and returning the matches with their surrounding context."
   (:require [clojure.zip :as z]
             clojure.set
             clojure.string
@@ -6,42 +9,36 @@
 
 ;; === zipper iterators
 
-(defn iter-while-identity
+(defn- iter-while-identity
   [f v]
   (->> v
        (iterate f)
        (take-while identity)))
 
-(defn right-sib-zips
+(defn- right-sib-zips
   [z]
   (->> z
        (iter-while-identity z/right)
        rest))
 
-(defn left-sib-zips
-  [z]
-  (->> z
-       (iter-while-identity z/left)
-       rest))
-
-(defn all-sib-zips [z]
+(defn- all-sib-zips [z]
   (let [lefty (z/leftmost z)
         zips (lazy-cat [lefty] (right-sib-zips lefty))
         not-z #(not (= % z))]
     (filter not-z zips)))
 
-(defn ancestor-zips
+(defn- ancestor-zips
   [z]
   (->> z
        (iter-while-identity z/up)
        rest))
 
-(defn children-zips [zipr]
+(defn- children-zips [zipr]
   (some->> zipr
            z/down
            (iter-while-identity z/right)))
 
-(defn children-zips-by-generation [zipr]
+(defn- children-zips-by-generation [zipr]
   (if (not-empty zipr)
     (let [zipr' (if (some-> zipr
                             meta
@@ -55,16 +52,15 @@
               (children-zips-by-generation kids)))
     nil))
 
-
 ;; === tags
 
-(defn get-tags
+(defn- get-tags
   [node pred-map]
   (vec (for [[kw pred] pred-map
              :when (pred node)]
          kw)))
 
-(defn get-tag-map
+(defn- get-tag-map
   [tree pred-map]
   (reduce (fn [tag-map node]
             (assoc tag-map
@@ -73,7 +69,7 @@
           {}
           (tree-seq map? :children tree)))
 
-(defn mk-get-tag-fn
+(defn- mk-get-tag-fn
   [tag-map]
   (fn [tree]
     (-> tree
@@ -82,14 +78,14 @@
 
 ;; === zippers
 
-(defn tree->zipper
+(defn- tree->zipper
   [tree]
   (z/zipper map?
             #(-> % :children not-empty)
             #(assoc % :children %2)
             tree))
 
-(defn traverse-assoc-zipper
+(defn- traverse-assoc-zipper
   [zipr]
   (if (z/end? zipr)
     (-> zipr z/root)
@@ -97,14 +93,8 @@
                (z/edit assoc :zipper zipr)
                z/next))))
 
-(defn traverse-tree-assoc-zipper
-  [tree]
-  (-> tree
-      tree->zipper
-      traverse-assoc-zipper))
-
 ;; move this to trace or utils?
-(defn traverse-tree
+(defn- traverse-tree
   [tree f]
   (assoc (f tree)
          :children (mapv #(traverse-tree % f)
@@ -116,7 +106,7 @@
 
 ;; === query
 
-(defn query-tree
+(defn- query-tree
   [qry-fn tree]
   (if-not (nil? tree)
     (let [e' (update-in tree [:children]
@@ -128,7 +118,7 @@
         (:children e')))
     []))
 
-(defn query-dos
+(defn- query-dos
   [tree pred-map pred-final-fn] ;; pred-final-fn takes a node (w/ :zipper) and fn to retrieve tags from a node
   (let [tag-map (get-tag-map tree pred-map)
         get-tag-fn (mk-get-tag-fn tag-map)
@@ -138,7 +128,7 @@
          traverse-assoc-zipper
          (query-tree pred-final-fn'))))
 
-(defn query-uno
+(defn- query-uno
   [tree pred-fn]
   (query-tree pred-fn tree))
 
@@ -147,7 +137,6 @@
   ([tree pred-map pred-final-fn] (query-dos tree pred-map pred-final-fn)))
 
 ;; === macro interface
-
 
 (defn get-some*
   [f v]
@@ -211,7 +200,7 @@
        (map mk-query-fn)
        (apply some-fn)))
 
-(defn every-pred-2
+(defn- every-pred-2
   [& preds]
   (fn [node tag-fn]
     (loop [[f & r] preds]
@@ -220,8 +209,7 @@
              (recur r)
              true)))))
 
-
-(defn mk-lazy-descendant-tag-seq
+(defn- mk-lazy-descendant-tag-seq
   [node tag-fn dist]
   (let [generations-seq (->> node
                              :zipper
@@ -234,8 +222,7 @@
          (map z/node)
          (mapcat tag-fn))))
 
-
-(defn mk-lazy-sibling-tag-seq
+(defn- mk-lazy-sibling-tag-seq
   [node tag-fn dist]
   (let [generations-seq (->> node
                              :zipper
@@ -247,7 +234,7 @@
          (map z/node)
          (mapcat tag-fn))))
 
-(defn mk-lazy-ancestor-tag-seq
+(defn- mk-lazy-ancestor-tag-seq
   [node tag-fn dist]
   (let [generations-seq (->> node
                              :zipper
@@ -259,7 +246,7 @@
          (map z/node)
          (mapcat tag-fn))))
 
-(defn mk-relative-final-qry-fn
+(defn- mk-relative-final-qry-fn
   [opts tag-set & [dist]]
   (fn [node tag-fn]
     (or (some tag-set (tag-fn node))
@@ -275,7 +262,7 @@
           (some (partial some tag-set)
                 tag-seq-coll)))))
 
-(defn parse-to-kw-chars
+(defn- parse-to-kw-chars
   [s]
   (->> s
        name
@@ -283,7 +270,7 @@
        (map str)
        (map keyword)))
 
-(defn query-dispatch-decider
+(defn- query-dispatch-decider
   [_ body]
   (let [[f & r] body]
     (if (-> f
@@ -327,7 +314,7 @@
          (every-pred-2 (mk-relative-final-qry-fn [:d] #{:a})
                        (mk-relative-final-qry-fn [:a] #{:d}))))
 
-(defn mk-query-result-root
+(defn- mk-query-result-root
   [tree]
   (vary-meta (if (-> tree
                      meta
@@ -351,25 +338,25 @@
 
 ;; ========================
 
-(defn get-pos
+(defn- get-pos
   [v]
   (-> (or (:src-pos v)
           (:meta v))
       (select-keys [:line :column :file :end-line :end-column])
       (assoc :ids #{(:id v)})))
 
-(defn start-dist
+(defn- start-dist
   [pos-line {:keys [line end-line]}]
   (when (<= (or end-line line) pos-line)
     (- pos-line (or end-line line))))
 
-(defn inside-width
+(defn- inside-width
   [pos-line {:keys [line end-line]}]
   (when (and end-line
              (<= line pos-line end-line))
     (- end-line line)))
 
-(defn compare-metric
+(defn- compare-metric
   [better worse]
   (cond
     (= nil better worse) nil
@@ -377,7 +364,7 @@
     (not worse) true
     :else (< better worse)))
 
-(defn merge-em
+(defn- merge-em
   [a b]
   (assoc a
          :ids (->> [a b]
@@ -388,7 +375,7 @@
                 :line -1
                 :end-line nil})
 
-(defn compare-thing
+(defn- compare-thing
   [line best next]
   (let [best (or best init-best)
         inside-width-best (inside-width line best)
@@ -415,13 +402,13 @@
       start-dist-equal (merge-em best next)
       (false? start-dist-best-better) next)))
 
-(defn file-paths-match?
+(defn- file-paths-match?
   [test path]
   (let [test' (clojure.string/replace test #"^file:" "")
         path' (clojure.string/replace path #"^file:" "")]
     (.endsWith test' path')))
 
-(defn get-best-match-in-tree-seq
+(defn- get-best-match-in-tree-seq
   [ts file line]
   (->> ts
        (map get-pos)
@@ -439,7 +426,7 @@
            (get-best-match-in-tree-seq $ file line)
            :ids))
 
-(defn compare-positions-against-line-range
+(defn- compare-positions-against-line-range
   [start-line line best next]
   (if (<= start-line
           (:line next))
@@ -448,7 +435,7 @@
                    next)
     best))
 
-(defn get-best-match-in-tree-seq-for-line-range
+(defn- get-best-match-in-tree-seq-for-line-range
   [ts file start-line line]
   (->> ts
        (map get-pos)

--- a/src/sayid/recording.clj
+++ b/src/sayid/recording.clj
@@ -1,4 +1,6 @@
 (ns sayid.recording
+  "Saved recordings: snapshotting a workspace's captured call tree onto a named
+  shelf and loading it back, so a recording survives resetting the workspace."
   (:require [sayid.workspace :as ws]
             [sayid.trace :as trace]
             [sayid.util.other :as util]
@@ -24,7 +26,7 @@
                  ::trace-root
                  true)))
 
-(defn ->recording
+(defn- ->recording
   [v]
   (let [mv (meta v)]
     (cond

--- a/src/sayid/string_output.clj
+++ b/src/sayid/string_output.clj
@@ -1,4 +1,7 @@
 (ns sayid.string-output
+  "Rendering a recorded call tree to text, with text-property spans (colours and
+  positions) for editor clients to consume - the presentation layer behind the
+  rendered nREPL ops."
   (:require [sayid.view :as v]
             [sayid.util.other :as util]
             [sayid.util.source :as src]
@@ -16,7 +19,7 @@
 
 (def colors-kw [:black :red :green :yellow :blue :magenta :cyan :white])
 
-(defn apply-color-palette
+(defn- apply-color-palette
   [n]
   (when n
     (nth *color-palette*
@@ -24,13 +27,13 @@
 
 (def line-break-token {:string "\n" :length 1 :line-break true})
 
-(defn render-tkns
+(defn- render-tkns
   [v]
   (if (-> v meta ::util/recur)
     (tam/render-tokens (apply list 'recur v))
     (tam/render-tokens v)))
 
-(defn tkn
+(defn- tkn
   [s & {:keys [fg fg* bg bg* bold] :as props}]
   (if (= s "\n")
     line-break-token
@@ -46,14 +49,14 @@
                    (get colors-kw (or bg (apply-color-palette bg*)))]
            :bold bold)))))
 
-(defn mk-lazy-color-fg*-str
+(defn- mk-lazy-color-fg*-str
   ([s] (mk-lazy-color-fg*-str s 0))
   ([s i] (lazy-cat [(tkn s :fg* i)]
                    (mk-lazy-color-fg*-str s (inc i)))))
 
 (def lazy-color-fg*-pipes (mk-lazy-color-fg*-str "|"))
 
-(defn slinky-pipes
+(defn- slinky-pipes
   [len & {:keys [end]}]
   (concat
    (take (- len (count end)) lazy-color-fg*-pipes)
@@ -62,14 +65,14 @@
      [])
    [(tkn " ")]))
 
-(def slinky-pipes-MZ (memoize slinky-pipes))
+(def ^:private slinky-pipes-MZ (memoize slinky-pipes))
 
-(defn indent
+(defn- indent
   [depth & {:keys [end]}]
   (slinky-pipes-MZ depth
                    :end end))
 
-(defn breaker
+(defn- breaker
   [f coll]
   (let [[head [delim & tail]] (split-with (complement f)
                                           coll)]
@@ -77,11 +80,11 @@
                         (breaker f tail)
                         []))))
 
-(defn get-line-length
+(defn- get-line-length
   [line]
   (->> line (map :length) (apply +)))
 
-(defn buffer-lines-to-width
+(defn- buffer-lines-to-width
   [width column]
   (map (fn [line]
          (let [buf-length (->> line (map :length) (apply +) (- width))]
@@ -91,7 +94,7 @@
              line)))
        column))
 
-(defn mk-column-str
+(defn- mk-column-str
   [indent & cols]
   (def i' indent)
   (def c' cols)
@@ -113,15 +116,13 @@
                               lines')
                         (repeat [(tkn "\n")]))))))
 
-(defn multi-line-indent2
+(defn- multi-line-indent2
   [& {:keys [cols indent-base]}]
   (->> cols
        (apply mk-column-str
               (repeat (indent indent-base)))))
 
-(def multi-line-indent2-MZ  (memoize multi-line-indent2))
-
-(defn get-line-meta
+(defn- get-line-meta
   [v & {:keys [path header?]}]
   (util/$- some-> (or (:src-pos v)
                       (:meta v))
@@ -142,7 +143,7 @@
            (assoc $
                   :line-meta? true)))
 
-(defn indent-arg-map
+(defn- indent-arg-map
   [tree m]
   (->> m
        (map (fn [[label value]]
@@ -152,7 +153,7 @@
                                       :indent-base (:depth tree))]))
        vec))
 
-(defn indent-map
+(defn- indent-map
   [tree m]
   (->> m
        (map (fn [[label value]]
@@ -161,7 +162,7 @@
                                     :indent-offset  3)))
        vec))
 
-(defn selects-str
+(defn- selects-str
   [tree selects]
   (let [sel-fn (fn [sel]
                  (util/get-some (if (vector? sel)
@@ -173,7 +174,7 @@
     [(get-line-meta tree)
      (indent-map tree sel-map)]))
 
-(defn throw-str
+(defn- throw-str
   [tree]
   (when-let [thrown (:throw tree)]
     [(get-line-meta tree
@@ -183,7 +184,7 @@
                                    (render-tkns thrown)]
                             :indent-base (:depth tree))]))
 
-(defn return-str
+(defn- return-str
   [tree & {pos :pos}]
   (when (contains? tree :return)
     (let [return (:return tree)]
@@ -196,12 +197,12 @@
                                      (render-tkns return)]
                               :indent-base (:depth tree))])))
 
-(defn args-map-str
+(defn- args-map-str
   [tree]
   (when-let [arg-map (:arg-map tree)]
     (indent-arg-map tree arg-map)))
 
-(defn args-str
+(defn- args-str
   [tree]
   (when-let [args (:args tree)]
     (->> args
@@ -211,7 +212,7 @@
                                                 :indent-base (:depth tree))]))
          vec)))
 
-(defn let-binds-str
+(defn- let-binds-str
   [tree]
   (->> tree
        :let-binds
@@ -225,7 +226,7 @@
                                               :indent-base (:depth tree))]))
        vec))
 
-(defn args*-str
+(defn- args*-str
   [tree]
   (let [test #(-> tree % not-empty)]
     ((cond
@@ -235,7 +236,7 @@
        :else (constantly (tkn "")))
      tree)))
 
-(defn name->string
+(defn- name->string
   [tree start?]
   (let [{:keys [depth name form ns parent-name macro? xpanded-frm]} tree]
     (if (nil? depth)
@@ -264,7 +265,7 @@
   `(when (~kw ~'view)
      [~@body]))
 
-(defn tree->string*
+(defn- tree->string*
   [tree]
   (if (nil? tree)
     []
@@ -296,13 +297,13 @@
                            :end "^")])
        (tkn "\n")])))
 
-(defn increment-position
+(defn- increment-position
   [line-break? line column pos]
   (if line-break?
     [(inc line) 0 pos]
     [line column pos]))
 
-(defn assoc-tokens-pos
+(defn- assoc-tokens-pos
   [tokens]
   (loop [[{:keys [length line-break line-meta?] :as head} & tail] tokens
          line-meta nil
@@ -329,11 +330,11 @@
                                          :end end-pos)
                                   (conj agg $)))))))
 
-(defn remove-nil-vals
+(defn- remove-nil-vals
   [m]
   (for [[k v] m :when (not (nil? v))] [k v]))
 
-(defn tkn->simple-type
+(defn- tkn->simple-type
   [t]
   (-> t :type first))
 
@@ -346,14 +347,14 @@
 
 (def ^:const  type->bg-color {:truncator :white})
 
-(defn apply-type-colors-to-token
+(defn- apply-type-colors-to-token
   [{[fg-color bg-color] :color :as token}]
   (let [st (tkn->simple-type token)]
     (assoc token
            :color [(or (type->color st) fg-color)
                    (or (type->bg-color st) bg-color)])))
 
-(defn mk-text-props
+(defn- mk-text-props
   [{:keys [start end] :as token}]
   (util/$- -> token
            (dissoc :coll?
@@ -373,8 +374,7 @@
            remove-nil-vals
            [start end $]))
 
-
-(defn tkn-prop-grouper4
+(defn- tkn-prop-grouper4
   [pos-pairs start end]
   (if (empty? pos-pairs) {:last-start start :last-end end :pairs []}
       (let [{:keys [last-start last-end pairs]} pos-pairs]
@@ -385,18 +385,18 @@
                  :last-end end
                  :pairs (conj pairs [last-start last-end]))))))
 
-(defn tkn-prop-grouper3
+(defn- tkn-prop-grouper3
   [start end]
   (fn [agg pos-pairs]
     (update-in agg pos-pairs tkn-prop-grouper4 start end)))
 
-(defn tkn-prop-grouper2
+(defn- tkn-prop-grouper2
   [agg [start end props]]
   (reduce (tkn-prop-grouper3 start end)
           agg
           props))
 
-(defn tkn-prop-grouper6
+(defn- tkn-prop-grouper6
   [pairs]
   (reduce (fn [agg [start end]]
             (update-in agg
@@ -405,7 +405,7 @@
           {}
           pairs))
 
-(defn tkn-prop-grouper5
+(defn- tkn-prop-grouper5
   [m]
   (reduce (fn [agg [a b c]]
             (if b
@@ -418,13 +418,13 @@
                 [k2 {:keys [last-end last-start pairs]}] kv]
             [k k2 (conj pairs [last-start last-end]) ])))
 
-(defn tkn-prop-grouper
+(defn- tkn-prop-grouper
   [triples]
   (tkn-prop-grouper5 (reduce tkn-prop-grouper2
                              {}
                              triples)))
 
-(defn split-text-tag-coll
+(defn- split-text-tag-coll
   [tokens]
   [(->> tokens (map :string) (apply str))
    (->> tokens
@@ -440,7 +440,7 @@
        (remove nil?)
        split-text-tag-coll))
 
-(defn audit-ns->summary-view
+(defn- audit-ns->summary-view
   [audit-ns]
   (let [[ns-sym audit-fns] audit-ns
         fn-count (count audit-fns)
@@ -452,7 +452,7 @@
     (tkn (format "  %s / %s  %s\n" traced-count fn-count ns-sym)
          :ns ns-sym)))
 
-(defn audit-fn->view
+(defn- audit-fn->view
   [[ fn-sym {:keys [trace-type trace-selection] :as  fn-meta}]]
   (apply tkn (format "  %s %s %s\n"
                      (case trace-selection
@@ -469,19 +469,19 @@
                      fn-sym)
          (apply concat fn-meta)))
 
-(defn audit-fn-group->view
+(defn- audit-fn-group->view
   [[ns-sym audit-fns]]
   (concat [(tkn (format "- in ns %s\n" ns-sym))]
           (map audit-fn->view audit-fns)))
 
-(defn audit->top-view
+(defn- audit->top-view
   [audit]
   (concat [(tkn "Traced namespaces:\n")]
           (map audit-ns->summary-view (:ns audit))
           [(tkn "\n\nTraced functions:\n")]
           (map audit-fn-group->view (:fn audit))))
 
-(defn audit->ns-view
+(defn- audit->ns-view
   [audit & [ns-sym]]
   (concat [(tkn (format "Namespace %s\n" ns-sym) :ns ns-sym)]
           (map audit-fn->view
@@ -489,9 +489,6 @@
           [(tkn "\n\nTraced functions:\n")]
           (map audit-fn->view
                (-> audit :fn (get ns-sym)))))
-
-
-
 
 (defn tree->string [tree]
   (->> tree
@@ -511,44 +508,7 @@
   (doseq [t trees]
     (print-tree t)))
 
-(defn ansi-color-code
-  ([] (ansi-color-code {}))
-  ([{:keys [fg-color bg-color]}]
-   (let [fg (.indexOf ^java.util.List colors-kw (or fg-color :white))
-         bg (.indexOf ^java.util.List colors-kw (or bg-color :black))]
-     (->> [(if (= fg -1) nil (+ 30 fg))
-           (if (= bg -1) nil (+ 40 bg))]
-          (remove nil?)
-          not-empty
-          (clojure.string/join ";")
-          (format "\33[%sm")))))
-
-(defn print-tree-ansi [tree]
-  (->> tree
-       tree->string*
-       flatten
-       (remove nil?)
-       (map apply-type-colors-to-token)
-       (mapcat (fn [t][(ansi-color-code t)
-                       (:string t)
-                       (ansi-color-code)]))
-       (apply str)
-       print))
-
-(defn print-trees-ansi
-  [trees]
-  (doseq [t trees]
-    (print-tree t)))
-
-(defn value->text-prop-pair
-  [a]
-  (->> a
-       render-tkns
-       flatten
-       (remove nil?)
-       split-text-tag-coll))
-
-(defn adjusted-pos
+(defn- adjusted-pos
   [n]
   (let [n' (or (some-> n :bounds first) n)
         {:keys [start start-line]} n']
@@ -556,57 +516,49 @@
       (-> start
           inc))))
 
-(defn find-up-node
+(defn- find-out-node
   [z]
   (let [up (some-> z z/up z/node)]
     (if (= (tkn->simple-type up) :map-entry)
       (some-> z z/up z/up z/node)
       up)))
 
-(defn find-out-node
-  [z]
-  (let [up (some-> z z/up z/node)]
-    (if (= (tkn->simple-type up) :map-entry)
-      (some-> z z/up z/up z/node)
-      up)))
-
-(defn find-in-node
+(defn- find-in-node
   [z]
   (let [down (some-> z z/down z/node)]
     (if (= (tkn->simple-type down) :map-entry)
       (some-> z z/down z/down z/right z/node)
       down)))
 
-(defn find-prev-node
+(defn- find-prev-node
   [z]
   (let [up (some-> z z/up z/node)]
     (if (= (tkn->simple-type up) :map-entry)
       (some-> z z/up z/left z/down z/right z/node)
       (some-> z z/left z/node))))
 
-(defn find-next-node
+(defn- find-next-node
   [z]
   (let [up (some-> z z/up z/node)]
     (if (= (tkn->simple-type up) :map-entry)
       (some-> z z/up z/right z/down z/right z/node)
       (some-> z z/right z/node))))
 
-
 (declare get-path)
 
-(defn update-last
+(defn- update-last
   [coll f]
   (update-in coll
              [(-> coll count dec)]
              f))
 
-(defn get-path-of-vec-child
+(defn- get-path-of-vec-child
   [z]
   (if-let [left (z/left z)]
     (update-last (get-path left) inc)
     (conj (-> z z/up get-path) 0)))
 
-(defn get-path
+(defn- get-path
   [z]
   (if-let [up (z/up z)]
     (let [parent (z/node up)]
@@ -621,7 +573,7 @@
         :set (get-path-of-vec-child z)))
     []))
 
-(defn decorate-token
+(defn- decorate-token
   [t]
   (let [z (:zipper t)
         out (adjusted-pos (find-out-node z))
@@ -637,7 +589,7 @@
                                 (clojure.string/join " " $))))
       t)))
 
-(defn split-text-tag-coll*
+(defn- split-text-tag-coll*
   [tokens]
   [(->> tokens (map :string) (apply str))
    (->> tokens
@@ -654,7 +606,7 @@
        (map decorate-token)
        split-text-tag-coll*))
 
-(defn tokens->text-prop-pair
+(defn- tokens->text-prop-pair
   [tokens]
   (->> tokens
        flatten

--- a/src/sayid/trace.clj
+++ b/src/sayid/trace.clj
@@ -1,4 +1,9 @@
 (ns sayid.trace
+  "Outer tracing: wrapping a var so each call records its arguments, return or
+  throw and timing into the active workspace's call tree.  Also home to the
+  dynamic vars that bound the recording - `*record-limit*`, `*max-trace-depth*`,
+  `*sample-rate*`, `*per-fn-limit*`, `*evict-old-calls*` - and the trace/untrace
+  multimethods that inner tracing extends."
   (:require [sayid.util.other :as util]
             [sayid.util.sym :as sym])
   (:import sayid.SayidMultiFn))
@@ -48,7 +53,7 @@
   failure at the end of a long run."
   false)
 
-(defn run-suppressed
+(defn- run-suppressed
   "Run `(apply F ARGS)` with recording suppressed for it and everything under it."
   [f args]
   (binding [*suppress-recording* true]
@@ -104,9 +109,14 @@
                     "workspace, or raise sayid.trace/*record-limit*, to record "
                     "more.")))))
 
-(defn now [] (System/currentTimeMillis))
+(defn now
+  "Current wall-clock time in milliseconds; stamps each node's start and end."
+  [] (System/currentTimeMillis))
 
 (defn mk-tree
+  "Build a fresh call-tree node: a map with a unique :id, its :path from the root,
+  :depth, and an empty :children atom.  PARENT supplies the path and depth to
+  extend."
   [& {:keys [id-prefix parent]}]
   (let [id (-> id-prefix
                gensym
@@ -119,7 +129,7 @@
              :depth (or (some-> parent :depth inc) 0)
              :children (atom [])}))
 
-(defn mk-fn-tree
+(defn- mk-fn-tree
   [& {:keys [parent name args meta]}]
   (assoc  (mk-tree :parent parent) ;; 3 sec
           :name name
@@ -131,7 +141,7 @@
                                           args))
           :started-at (now)))
 
-(defn StackTraceElement->map
+(defn- StackTraceElement->map
   [^StackTraceElement o]
   {:class-name (.getClassName o)
    :file-name (.getFileName o)
@@ -163,14 +173,13 @@
       (assoc m :data data)
       m)))
 
-
-(defn start-trace
+(defn- start-trace
   [trace-log tree]
   (swap! trace-log
          conj
          tree))  ;; string!!
 
-(defn end-trace
+(defn- end-trace
   [trace-log idx tree]
   (swap! trace-log
          update-in
@@ -196,7 +205,7 @@
              (update roots i #(merge % tree))
              roots))))
 
-(defn record-root-call-evicting
+(defn- record-root-call-evicting
   "Record a top-level call while keeping only the most recent `*record-limit*`
   roots: append this call and drop the oldest beyond the limit.  Ends by id, so
   the index-shifting from eviction can't corrupt an in-flight call."
@@ -225,7 +234,7 @@
                        :ended-at (now)})
       value)))
 
-(defn record-fn-call
+(defn- record-fn-call
   [parent name f args meta']
   (bump-per-fn-count! name)
   (let [this  (mk-fn-tree :parent parent
@@ -251,7 +260,7 @@
                   :ended-at (now)})
       value)))
 
-(defn trace-fn-call
+(defn- trace-fn-call
   [workspace name f args meta']
   (if *suppress-recording*
     ;; We're inside a call we chose not to record - stay untraced.
@@ -289,7 +298,7 @@
         :else
         (record-fn-call parent name f args meta')))))
 
-(defn shallow-tracer-multifn
+(defn- shallow-tracer-multifn
   [{:keys [workspace qual-sym meta']} original-fn]
   (sayid.SayidMultiFn. {:original original-fn
                                      :trace-dispatch-fn (fn [f args]
@@ -306,6 +315,9 @@
                                                                        meta'))}))
 
 (defn ^{::trace-type :fn} shallow-tracer
+  "The outer tracer: wrap ORIGINAL-FN so each call records its arguments, return or
+  throw and timing into the workspace.  M carries the workspace, the qualified
+  symbol and the var's metadata.  Multimethods are wrapped specially."
   [{:keys [workspace qual-sym meta'] :as m} original-fn]
   (if (= (type original-fn) clojure.lang.MultiFn)
     (shallow-tracer-multifn m original-fn)
@@ -316,7 +328,7 @@
                      args
                      meta'))))
 
-(defn apply-trace-to-var
+(defn- apply-trace-to-var
   [^clojure.lang.Var v tracer-fn workspace]
   (let [ns (.ns v)
         s  (.sym v)
@@ -334,6 +346,8 @@
       (alter-meta! assoc ::trace-type (-> tracer-fn meta ::trace-type)))))
 
 (defn untrace-var*
+  "Restore a traced var to its original function, dropping Sayid's trace metadata.
+  A no-op if the var isn't traced."
   ([ns s]
    (untrace-var* (ns-resolve ns s)))
   ([v]
@@ -349,6 +363,9 @@
                       ::trace-type))))))
 
 (defn trace-var*
+  "Install TRACER-FN on var V for WORKSPACE.  Re-traces if V is already traced by a
+  different workspace or trace type (unless :no-overwrite is set); skips macros and
+  non-functions."
   [v tracer-fn workspace & {:keys [no-overwrite]}]
   (let [^clojure.lang.Var v (if (var? v) v (resolve v))]
     (when (and (ifn? @v) (-> v meta :macro not))
@@ -361,13 +378,13 @@
           (apply-trace-to-var v tracer-fn workspace))
         (apply-trace-to-var v tracer-fn workspace)))))
 
-(defn the-ns-safe
+(defn- the-ns-safe
   [ns]
   (try (the-ns ns)
        (catch Exception e
          nil)))
 
-(defn trace-ns*
+(defn- trace-ns*
   [ns workspace]
   (when-let [ns (the-ns-safe ns)]
     (when-not ('#{clojure.core sayid.core} (ns-name ns))
@@ -380,17 +397,18 @@
                       :no-overwrite true))))))
 
 (defn untrace-ns*
+  "Untrace every traced var in namespace NS*."
   [ns*]
   (when-let [ns' (the-ns-safe ns*)]
     (let [ns-fns (->> ns' ns-interns vals)]
       (doseq [f ns-fns]
         (untrace-var* f)))))
 
-(defn apply->vec
+(defn- apply->vec
   [f]
   (fn [v] [v (f v)]))
 
-(defn audit-fn
+(defn- audit-fn
   [fn-var trace-selection]
   (let [fn-meta (meta fn-var)]
     (-> fn-meta
@@ -400,13 +418,9 @@
         (dissoc ::trace-type
                 ::traced))))
 
-(defn audit-fn-sym
-  [fn-sym trace-selection]
-  (-> fn-sym
-      resolve
-      (audit-fn trace-selection)))
-
 (defn audit-ns
+  "A sorted map of every function in NS-SYM to its trace-audit info (its metadata
+  plus current trace type) - the data behind reporting what's traced."
   [ns-sym]
   (try (let [mk-vec-fn (fn [fn-var]
                          [(-> fn-var meta :name)
@@ -421,6 +435,9 @@
          (sorted-map))))
 
 (defn audit-traces
+  "Summarize a workspace's TRACED selection as data: which namespaces are traced
+  wholesale, and - grouped by namespace - each individually traced function with
+  its trace type.  Backs the show-traced views."
   [traced]
   (let [{outer :fn inner :inner-fn ns' :ns} traced
         f (fn [trace-type]
@@ -439,6 +456,8 @@
      :fn fn-audits}))
 
 (defn check-fn-trace-type
+  "The trace type currently applied to FN-SYM (`:fn`, `:inner-fn`, ...), or nil when
+  it isn't traced."
   [fn-sym]
   (-> fn-sym
       resolve
@@ -450,8 +469,6 @@
 (defmethod trace* :ns
   [_ sym workspace]
   (trace-ns* sym workspace))
-
-
 
 (defmethod trace* :fn
   [_ fn-sym workspace]

--- a/src/sayid/util/find_ns.clj
+++ b/src/sayid/util/find_ns.clj
@@ -1,7 +1,9 @@
 (ns sayid.util.find-ns
+  "Helpers for discovering loaded namespaces by name or wildcard pattern, used by
+  the trace-by-pattern operations."
   (:require [sayid.util.other :as util]))
 
-(defn unnest-symbol
+(defn- unnest-symbol
   [s]
   (cond
     (symbol? s) s
@@ -12,7 +14,7 @@
 
     :else nil))
 
-(defn alias->ns
+(defn- alias->ns
   [s ref-ns]
   (some-> ref-ns
           ns-aliases
@@ -20,7 +22,7 @@
           str
           symbol))
 
-(defn re-find-nses
+(defn- re-find-nses
   [q]
   (when-let [re (util/$- some->> q
                          name

--- a/src/sayid/util/other.clj
+++ b/src/sayid/util/other.clj
@@ -36,18 +36,18 @@
   (into {} (map (fn [[k v]] [k (f v)])
                 m)))
 
-(defn clear-meta
+(defn- clear-meta
   [v]
   (with-meta v nil))
 
-(defn cleanse-arglist
+(defn- cleanse-arglist
   "Clear out pre-condtions and tags."
   [arglist]
   (->> arglist
        clear-meta
        (mapv clear-meta)))
 
-(defn arg-matcher-fn
+(defn- arg-matcher-fn
   [arglists]
   (when (not-empty arglists)
     (let [arities (map #(list % '(sayid.util.other/get-env)) ;; NOTE!  NS/get-env must match this ns
@@ -55,9 +55,9 @@
           fn1  `(fn ~@arities)]
       (eval fn1))))
 
-(def arg-matcher-fn-memo (memoize arg-matcher-fn))
+(def ^:private arg-matcher-fn-memo (memoize arg-matcher-fn))
 
-(defn arg-match
+(defn- arg-match
   [arglists args]
   (if (not-empty arglists)
     (let [args-v (vec args)
@@ -74,7 +74,7 @@
     (catch Exception e
       nil)))
 
-(defn atom?
+(defn- atom?
   [v]
   (instance? clojure.lang.Atom v))
 
@@ -84,17 +84,17 @@
     @maybe-atom
     maybe-atom))
 
-(defn derefable?
+(defn- derefable?
   [v]
   (instance? clojure.lang.IDeref v))
 
-(defn derefable?->
+(defn- derefable?->
   [maybe-ideref]
   (if (derefable? maybe-ideref)
     @maybe-ideref
     maybe-ideref))
 
-(defn obj-pred-action-else
+(defn- obj-pred-action-else
   [obj pred & {:keys [t t-fn f f-fn]}]
   (let [pred' (or pred identity)]
     (if (pred' obj)
@@ -119,7 +119,7 @@
       (obj-pred-action-else symbol? :t-fn #(ns-resolve ns-sym %))
       derefable?->))
 
-(defn replace$
+(defn- replace$
   [form]
   (let [$sym `$#
         form' (walk/prewalk-replace {'$ $sym}
@@ -144,7 +144,7 @@
                                                    (name '~source)
                                                    %))))))
 
-(defn defalias-macro*
+(defn- defalias-macro*
   [alias source]
   (let [body-sym (gensym "body")
         qualified-source (sym/qualify-sym *ns* source)
@@ -186,21 +186,6 @@
   [& body]
   `(alter-meta! ~body assoc :source '~body))
 
-(defn back-into
-  "Puts the contents of `noob` into a collection of the same type as `orig`."
-  [orig noob]
-  ((if (seq? orig)
-     reverse
-     identity)
-   (into (or (empty orig)
-             [])
-         noob)))
-
-(defn deep-zipmap
-       [a b]
-       (zipmap (tree-seq coll? seq a)
-               (tree-seq coll? seq b)))
-
 (defn flatten-map-kv-pairs
   [m]
   (mapcat (fn [[k v]]
@@ -217,7 +202,6 @@
               (-> #'~fn-sym
                   meta
                   ~meta-key)))
-
 
 (defn get-some*
   [f v]
@@ -240,7 +224,6 @@
       (let [[f & r] coll]
         (when-let [v' (get-some* f v)]
           (recur r v'))))))
-
 
 (defn quote-if-sym
   [v]

--- a/src/sayid/view.clj
+++ b/src/sayid/view.clj
@@ -1,4 +1,6 @@
 (ns sayid.view
+  "Views: named predicate/selector filters that control which parts of a recorded
+  node the renderers show (e.g. hide args, show only returns)."
   (:require [sayid.util.other :as util]))
 
 
@@ -28,7 +30,7 @@
         (when-let [v' (get-some* f v)]
           (recur r v'))))))
 
-(defn wrap-wildcards
+(defn- wrap-wildcards
   [re]
   (re-pattern (str ".*" re ".*")))
 
@@ -69,7 +71,7 @@
 
 ;; ==================================================================
 
-(defn pred-sel-pairs->view
+(defn- pred-sel-pairs->view
   [pairs]
   (let [pairs' (map (fn [[pred sel]]
                       [(-> pred
@@ -81,7 +83,7 @@
          (map first)
          (apply some-fn))))
 
-(defn pred-sel-pair->pred-fn
+(defn- pred-sel-pair->pred-fn
   [[pred sel]]
   (fn [tree]
     (if ((-> pred

--- a/src/sayid/workspace.clj
+++ b/src/sayid/workspace.clj
@@ -1,4 +1,7 @@
 (ns sayid.workspace
+  "The in-memory capture store: the active workspace that traces record into, and
+  the operations over it - reset, clear the log, enable/disable/remove traces, and
+  look up what's traced."
   (:require [sayid.trace :as trace]
             [sayid.util.other :as util]
             [sayid.util.sym :as sym]
@@ -20,14 +23,7 @@
                  :trace-root
                  true)))
 
-(defn workspace->tree
-  [ws]
-  (-> ws
-      (dissoc :traced
-              :ws-slot)
-      (vary-meta dissoc ::workspace)))
-
-(defn lookup-traces-by-fn
+(defn- lookup-traces-by-fn
   [ws fn-sym]
   (let [[ns-sym] (sym/disqualify-sym fn-sym)]
     (->> ws
@@ -50,11 +46,6 @@
   [ws]
   (trace/reset-bounds!)
   (reset! ws nil))
-
-(defn new-log!
-  [ws]
-  (trace/reset-bounds!)
-  (swap! ws assoc :children (atom [])))
 
 (defn clear-log!
   [ws]


### PR DESCRIPTION
A pre-0.6.0 pass over docstrings and API visibility (the code was light on both), plus the small README note that Sayid is named after *Lost*'s Sayid Jarrah.

**Docstrings**
- Every namespace that lacked one now has an orientation docstring stating its role.
- `sayid.core` (the public REPL API) and `sayid.trace` (the tracing engine) are now fully documented - the namespaces that surface on cljdoc.

**Visibility**
- ~180 functions that were public only by accident - referenced nowhere outside their own namespace - are now `defn-`/`^:private` (or `^:no-doc` for core's internal impl variants, matching the existing convention). Smaller API surface, and it shrinks the docstring gap at the same time.
- Marking them private surfaced ~20 genuinely **dead** functions (unused anywhere, several left over from the deleted legacy inner-tracer). Those are removed.

Net ~85 fewer lines, no behaviour change. Full suite and clj-kondo stay green; the visibility changes are safe because calling a now-private var across namespaces would fail to compile.
