### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## [0.6.0] - 2026-07-08
 
 * Rebuild inner tracing on `tools.analyzer.jvm` (`sayid.inner-ast`), working off the analyzed AST instead of re-reading source and rewriting raw forms. This replaces the legacy rewriter (the `sayid.inner-trace` namespace is gone), fixes inner-traced `try/catch` swallowing exceptions, and drops the per-macro special-casing that made the old instrumenter fragile.
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ provides a very flexible Sayid API. Its ops are documented in
 
 Add this to the dependencies in your project.clj or lein profiles.clj:
 
-    [mx.cider/sayid "0.5.0"]
+    [mx.cider/sayid "0.6.0"]
 
 To use the bundled nREPL middleware, you'll want to include Sayid as a
 plug-in. Here's an example of a bare-bones profiles.clj that works for
 me:
 
 ```clojure
-{:user {:plugins [[mx.cider/sayid "0.5.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.6.0"]]}}
 ```
 
 ### Clojure CLI - deps.edn
@@ -96,7 +96,7 @@ tools.deps config directory (often `$HOME/.clojure`).
 
 ```clojure
 {:deps
-  {mx.cider/sayid {:mvn/version "0.5.0"}}}
+  {mx.cider/sayid {:mvn/version "0.6.0"}}}
 ```
 
 ### Emacs Integration
@@ -121,7 +121,7 @@ that works for me:
 
 ```clojure
 {:user {:plugins [[cider/cider-nrepl "0.59.0"]
-                  [mx.cider/sayid "0.5.0"]]
+                  [mx.cider/sayid "0.6.0"]]
         :dependencies [[nrepl/nrepl "1.3.1"]]}}
 ```
 

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -11,7 +11,7 @@ This document is the reference for that wire API.
 With Leiningen, add Sayid as a plugin (it registers the middleware automatically):
 
 ```clojure
-{:user {:plugins [[mx.cider/sayid "0.5.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.6.0"]]}}
 ```
 
 Or add the middleware explicitly when you start the server, e.g. with the
@@ -259,7 +259,7 @@ Remove all traces and clear the recorded calls. Takes no params. Replies
 
 ### `sayid-version`
 
-Replies with the Sayid version string (e.g. `"0.5.0"`).
+Replies with the Sayid version string (e.g. `"0.6.0"`).
 
 ### `sayid-get-trace-count`
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mx.cider/sayid "0.5.0"
+(defproject mx.cider/sayid "0.6.0"
   :description "Sayid is a library for debugging and profiling clojure code."
   :url "https://github.com/clojure-emacs/sayid"
   :scm {:name "git" :url "https://github.com/clojure-emacs/sayid"}

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -4,7 +4,7 @@
 
 ;; Author: Bill Piel <bill@billpiel.com>
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
-;; Version: 0.5.0
+;; Version: 0.6.0
 ;; URL: https://github.com/clojure-emacs/sayid
 ;; Package-Requires: ((emacs "28") (cider "1.23"))
 ;; Keywords: clojure, cider, debugger
@@ -51,11 +51,11 @@ The injected dependencies are most likely nREPL middlewares."
   :type 'boolean)
 
 (defconst sayid-version
-  "0.5.0"
+  "0.6.0"
   "The current version of sayid.")
 
 (defconst sayid-injected-plugin-version
-  "0.5.0"
+  "0.6.0"
   "The version of the sayid Lein plugin to be automatically injected.")
 
 (defface sayid-int-face '((t :inherit default))

--- a/src/sayid/core.clj
+++ b/src/sayid/core.clj
@@ -18,7 +18,7 @@
 
 (def version
   "The current version of sayid as a string."
-  "0.5.0")
+  "0.6.0")
 
 (def workspace
   "The active workspace. Used by default in any function prefixed `ws-`

--- a/src/sayid/plugin.clj
+++ b/src/sayid/plugin.clj
@@ -2,7 +2,7 @@
 
 (def version
   "The current version of sayid as a string."
-  "0.5.0")
+  "0.6.0")
 
 (defn middleware
   [project]


### PR DESCRIPTION
Cuts 0.6.0. Bumps the version everywhere `doc/releasing.md` lists and dates the changelog.

The headline is the **inner-tracing rebuild**: inner tracing now works off the `tools.analyzer.jvm` AST instead of re-reading source and rewriting raw forms. That kills the per-macro fragility (the old rewriter needed bespoke patches and could detonate on constructs it hadn't seen), fixes inner-traced `try/catch` swallowing exceptions, and let the entire legacy `sayid.inner-trace` namespace be deleted. Rounded out by a documentation and visibility pass: namespace docstrings throughout, a fully documented public API, and ~180 accidental-public helpers made private (with the dead code that surfaced removed).

Deploy (dual-coordinate Clojars) and tagging happen after this merges.
