### PR TITLE
Add golden-trace testing (sayid.golden)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Add `sayid.golden`, a golden-trace testing helper: capture a run's recorded call tree as a normalized baseline and assert future runs still match it (`gold/matches-golden?`), with an update mode via `SAYID_GOLDEN_UPDATE`. With inner tracing the baseline covers intermediate expression values too.
+
 ## [0.6.0] - 2026-07-08
 
 * Rebuild inner tracing on `tools.analyzer.jvm` (`sayid.inner-ast`), working off the analyzed AST instead of re-reading source and rewriting raw forms. This replaces the legacy rewriter (the `sayid.inner-trace` namespace is gone), fixes inner-traced `try/catch` swallowing exceptions, and drops the per-macro special-casing that made the old instrumenter fragile.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,37 @@ Some other useful entry points:
 * `(sd/ws-clear-log!)` clears the recorded calls without removing the traces.
 * `(sd/ws-reset!)` removes all traces and clears the log.
 
+## Golden-trace testing
+
+Because a recorded trace is just data, you can pin it down as a test baseline.
+`sayid.golden` traces some code, runs it, and asserts the recorded call tree - the
+functions called, their arguments and return values, the nesting, and (with inner
+tracing) every intermediate expression value - still matches a stored golden file.
+It's regression testing at the level of *how* your code ran, which a plain
+return-value assertion can't see:
+
+```clojure
+(require '[sayid.core :as sd]
+         '[sayid.golden :as gold]
+         '[clojure.test :refer [deftest is]])
+
+(deftest orders-golden
+  (sd/ws-reset!)
+  (sd/ws-add-trace-ns! my.orders)
+  (my.orders/place-order sample-order)
+  (is (gold/matches-golden? "place-order")))
+```
+
+The first run writes `test/golden/place-order.edn` for you to review and commit;
+later runs compare against it and fail with a diff when the execution changes.
+When a change is intentional, regenerate the goldens by running with
+`SAYID_GOLDEN_UPDATE=1` set (or `(binding [gold/*update* true] ...)`).
+
+With an *inner* trace the golden captures the values *inside* each function too, so
+a baseline for `(fn [a b] (let [s (+ a b)] (if (> s 10) (* s 2) s)))` records
+`(+ a b) => 13`, `(> s 10) => true` and `(* s 2) => 26` - a regression net neither
+`tools.trace` nor a stepping debugger can give you.
+
 ## Using Sayid
 
 **Note: this assumes you're using the official CIDER plugin.**

--- a/src/sayid/golden.clj
+++ b/src/sayid/golden.clj
@@ -1,0 +1,144 @@
+(ns sayid.golden
+  "Golden-trace testing: assert that a run's *execution* matches a recorded
+  baseline, not just its final output.
+
+  Trace some code, run it, and compare the recorded call tree - functions called,
+  arguments, return values, nesting, and (with inner tracing) the intermediate
+  expression values - against a stored golden file.  When the trace changes, the
+  test fails with a diff; when the change is intentional, regenerate the golden.
+
+  This is regression testing at the level of *how* your code ran, which a plain
+  return-value assertion can't see and neither `tools.trace` nor a stepping
+  debugger offers.
+
+  Typical use in `clojure.test`:
+
+      (require '[sayid.core :as sd] '[sayid.golden :as gold])
+
+      (deftest orders-golden
+        (sd/ws-reset!)
+        (sd/ws-add-trace-ns! my.orders)
+        (my.orders/place-order sample-order)
+        (is (gold/matches-golden? \"place-order\")))
+
+  The first run writes `test/golden/place-order.edn` (review and commit it);
+  later runs compare against it.  Regenerate goldens by binding `*update*` true or
+  setting the `SAYID_GOLDEN_UPDATE` environment variable."
+  (:require [sayid.core :as sd]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [clojure.data :as data]
+            [clojure.pprint :as pp]))
+
+(def ^:dynamic *golden-dir*
+  "Directory the golden `.edn` files live in.  Defaults to `test/golden`."
+  "test/golden")
+
+(def ^:dynamic *update*
+  "When true, `check-golden` (re)writes the golden instead of comparing.  Defaults
+  to whether the `SAYID_GOLDEN_UPDATE` environment variable is set."
+  (some? (System/getenv "SAYID_GOLDEN_UPDATE")))
+
+;;; ---- normalization ------------------------------------------------------
+
+(defn- pr-val
+  "Print a captured value deterministically and boundedly, so a fat or lazy value
+  can't bloat or hang the golden."
+  [v]
+  (binding [*print-length* 100
+            *print-level* 10]
+    (pr-str v)))
+
+(defn- drop-nils [m]
+  (into {} (remove (comp nil? val) m)))
+
+(defn normalize-node
+  "Project a recorded node onto the stable, comparable fields: the function or
+  expression, its arguments and return-or-throw as printed values, inner-trace
+  tags, and children.  Drops everything volatile - ids, paths, timings, source
+  metadata, and the throw's stacktrace."
+  [node]
+  (drop-nils
+   {:name (some-> (:name node) str)
+    :form (some-> (:form node) pr-str)
+    :args (when (contains? node :args) (mapv pr-val (:args node)))
+    :return (when (contains? node :return) (pr-val (:return node)))
+    :throw (when-let [th (:throw node)]
+             {:type (some-> (get-in th [:via 0 :type]) pr-str)
+              :message (:cause th)})
+    :inner-tags (:inner-tags node)
+    :children (when (seq (:children node))
+                (mapv normalize-node (:children node)))}))
+
+(defn golden-trace
+  "The normalized golden trace of the active workspace (or workspace W): a vector
+  of the recorded root call trees."
+  [& [w]]
+  (mapv normalize-node (:children (if w (sd/ws-deref! w) (sd/ws-deref!)))))
+
+;;; ---- storage ------------------------------------------------------------
+
+(defn- sort-nested
+  "Recursively replace maps with sorted-maps so the written EDN has stable key
+  order and diffs cleanly."
+  [x]
+  (cond
+    (map? x) (into (sorted-map) (map (fn [[k v]] [k (sort-nested v)])) x)
+    (vector? x) (mapv sort-nested x)
+    :else x))
+
+(defn- golden-file ^java.io.File [name]
+  (io/file *golden-dir* (str name ".edn")))
+
+(defn read-golden
+  "Read the stored golden NAME, or nil if it doesn't exist yet."
+  [name]
+  (let [f (golden-file name)]
+    (when (.exists f)
+      (edn/read-string (slurp f)))))
+
+(defn write-golden!
+  "Write DATA as the golden NAME, creating the directory if needed.  Returns the
+  file."
+  [name data]
+  (let [f (golden-file name)]
+    (io/make-parents f)
+    (spit f (with-out-str
+              (binding [*print-length* nil *print-level* nil]
+                (pp/pprint (sort-nested data)))))
+    f))
+
+;;; ---- comparison ---------------------------------------------------------
+
+(defn check-golden
+  "Compare DATA against the stored golden NAME.  Returns a map whose `:status` is
+  one of `:created` (no golden existed - wrote it), `:updated` (`*update*` was on -
+  rewrote it), `:match`, or `:mismatch` (with a `:diff` of
+  [in-golden-only in-run-only])."
+  [name data]
+  (let [existing (read-golden name)]
+    (cond
+      (nil? existing)     (do (write-golden! name data) {:status :created})
+      *update*            (do (write-golden! name data) {:status :updated})
+      (= existing data)   {:status :match}
+      :else               {:status :mismatch
+                           :diff (vec (take 2 (data/diff existing data)))})))
+
+(defn matches-golden?
+  "Assert the active workspace's normalized trace matches golden NAME.  Returns
+  true on a match (or when the golden was just created/updated, printing a notice);
+  on a mismatch prints the diff and returns false, so it reads naturally inside
+  `(is (matches-golden? ...))`."
+  [name & [w]]
+  (let [{:keys [status diff]} (check-golden name (golden-trace w))]
+    (case status
+      :match true
+      :created (do (println "sayid golden:" (str (golden-file name))
+                            "created - review and commit it.")
+                   true)
+      :updated (do (println "sayid golden:" (str (golden-file name)) "updated.")
+                   true)
+      :mismatch (do (println "sayid golden mismatch for" (pr-str name) "-")
+                    (println "  only in golden:" (pr-str (first diff)))
+                    (println "  only in run:   " (pr-str (second diff)))
+                    false))))

--- a/test/golden/arith-inner.edn
+++ b/test/golden/arith-inner.edn
@@ -1,0 +1,7 @@
+[{:args ["6" "7"],
+  :children
+  [{:form "(+ a b)", :name "+", :return "13"}
+   {:form "(> s 10)", :name ">", :return "true"}
+   {:form "(* s 2)", :name "*", :return "26"}],
+  :name "sayid.inner-corpus/arith",
+  :return "26"}]

--- a/test/golden/nested-calls-outer.edn
+++ b/test/golden/nested-calls-outer.edn
@@ -1,0 +1,8 @@
+[{:args ["1" "2"],
+  :children
+  [{:args ["[2 2 2]"],
+    :name "sayid.inner-corpus/threaded",
+    :return "0"}
+   {:args ["1" "0"], :name "sayid.inner-corpus/arith", :return "1"}],
+  :name "sayid.inner-corpus/nested-calls",
+  :return "1"}]

--- a/test/sayid/golden_test.clj
+++ b/test/sayid/golden_test.clj
@@ -1,0 +1,51 @@
+(ns sayid.golden-test
+  (:require [clojure.test :as t]
+            [clojure.java.io :as io]
+            [sayid.core :as sd]
+            [sayid.golden :as gold]
+            [sayid.inner-corpus :as c]))
+
+(defn- fixture [f]
+  (with-out-str (sd/ws-reset!))
+  (f)
+  (with-out-str (sd/ws-reset!)))
+
+(t/use-fixtures :each fixture)
+
+;;; ---- the mechanism, against a throwaway directory ----------------------
+
+(t/deftest golden-mechanism
+  (let [dir (str "target/golden-test-" (System/nanoTime))]
+    (binding [gold/*golden-dir* dir
+              gold/*update* false]
+      (let [data [{:name "f" :args ["1"] :return "1"}]]
+        (t/testing "first check creates the golden"
+          (t/is (= :created (:status (gold/check-golden "m" data)))))
+        (t/testing "matching data matches"
+          (t/is (= :match (:status (gold/check-golden "m" data)))))
+        (t/testing "changed data is a mismatch, with a diff"
+          (let [r (gold/check-golden "m" [{:name "f" :args ["1"] :return "2"}])]
+            (t/is (= :mismatch (:status r)))
+            (t/is (= [{:return "1"}] (first (:diff r))))
+            (t/is (= [{:return "2"}] (second (:diff r))))))
+        (t/testing "update mode rewrites the golden"
+          (binding [gold/*update* true]
+            (t/is (= :updated (:status (gold/check-golden "m" [{:name "g"}])))))
+          (t/is (= [{:name "g"}] (gold/read-golden "m")))))
+      (doseq [f (reverse (file-seq (io/file dir)))] (.delete f)))))
+
+;;; ---- worked examples, against committed goldens ------------------------
+
+(t/deftest outer-trace-golden
+  ;; The recorded call tree of an outer trace: which functions ran, with what
+  ;; arguments and return values, and how they nested.
+  (sd/ws-add-trace-ns! sayid.inner-corpus)
+  (c/nested-calls 1 2)
+  (t/is (gold/matches-golden? "nested-calls-outer")))
+
+(t/deftest inner-trace-golden
+  ;; The differentiator: the golden captures every intermediate expression value
+  ;; *inside* the function, not just the call and its result.
+  (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)
+  (c/arith 6 7)
+  (t/is (gold/matches-golden? "arith-inner")))


### PR DESCRIPTION
The first move of **initiative 5** (position and extend): golden-trace testing - a capability that's clearly Sayid's own, built on the bounded, comparable, data-first captures the earlier initiatives laid down.

`sayid.golden` traces some code, runs it, normalizes the recorded call tree (strips ids/timings/source metadata, prints captured values under bounded print-length/level so nothing bloats or hangs), and compares it against a stored golden `.edn`. First run writes the golden to review and commit; later runs fail with a diff when the execution changes. Regenerate with `SAYID_GOLDEN_UPDATE=1` or `(binding [gold/*update* true] ...)`.

```clojure
(deftest orders-golden
  (sd/ws-reset!)
  (sd/ws-add-trace-ns! my.orders)
  (my.orders/place-order sample-order)
  (is (gold/matches-golden? "place-order")))
```

It's regression testing at the level of **how** your code ran - and with an *inner* trace the baseline captures every intermediate expression value, not just calls and results. The committed `arith-inner.edn` example shows this: the golden records `(+ a b) => 13`, `(> s 10) => true`, `(* s 2) => 26` inside the function. Neither `tools.trace` nor a stepping debugger offers that.

Ships with a self-test of the mechanism (create / match / mismatch-with-diff / update) plus two worked examples with committed goldens, and a README section.
