### PR TITLE
Add sayid.data: the recorded trace as plain, scriptable data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add `sayid.data`, the programmatic data-first API: `trace-data` returns the recorded call tree as plain keyword-keyed Clojure data with live captured values (and timing/source), and `tap-trace!` `tap>`s it for exploring in Portal/Reveal/Morse.
 * Add `sayid.golden`, a golden-trace testing helper: capture a run's recorded call tree as a normalized baseline and assert future runs still match it (`gold/matches-golden?`), with an update mode via `SAYID_GOLDEN_UPDATE`. With inner tracing the baseline covers intermediate expression values too.
 
 ## [0.6.0] - 2026-07-08

--- a/README.md
+++ b/README.md
@@ -185,6 +185,30 @@ Some other useful entry points:
 * `(sd/ws-clear-log!)` clears the recorded calls without removing the traces.
 * `(sd/ws-reset!)` removes all traces and clears the log.
 
+## The trace is data
+
+The recorded execution isn't just something to look at - it's a plain Clojure data
+structure you can script. `sayid.data/trace-data` hands you the call tree with
+keyword keys and the captured values kept *live*, so ordinary `map`/`filter`/`->>`
+work on it:
+
+```clojure
+(require '[sayid.core :as sd] '[sayid.data :as sd-data])
+
+(sd/ws-add-trace-ns! my.ns)
+(my.ns/run)
+
+;; every recorded call that took longer than 100ms
+(->> (sd-data/trace-data)
+     (tree-seq :children :children)
+     (filter #(some-> (:ms %) (> 100))))
+```
+
+And since it's just data, exploring a trace in
+[Portal](https://github.com/djblue/portal), Reveal or Morse is a one-liner -
+`(sd-data/tap-trace!)` taps the whole tree to your data viewer of choice, no
+Sayid-specific rendering involved.
+
 ## Golden-trace testing
 
 Because a recorded trace is just data, you can pin it down as a test baseline.

--- a/src/sayid/data.clj
+++ b/src/sayid/data.clj
@@ -1,0 +1,58 @@
+(ns sayid.data
+  "The recorded execution as plain, navigable Clojure data - the programmatic
+  counterpart to the nREPL data ops.
+
+  Where the nREPL data ops project the call tree for the wire (string keys,
+  `pr-str`'d values, so it round-trips over bencode), this projects it for
+  *scripting*: keyword keys and the captured values kept live, so you can walk,
+  filter, and drill into them with ordinary Clojure - or hand the whole thing to a
+  data-inspection tool.
+
+  Because it's just `tap>`-able data, exploring a trace in
+  [Portal](https://github.com/djblue/portal), Reveal or Morse is a one-liner:
+
+      (require '[sayid.core :as sd] '[sayid.data :as sd-data])
+      (sd/ws-add-trace-ns! my.ns)
+      (my.ns/run)
+      (sd-data/tap-trace!)   ; now explore it in Portal"
+  (:require [sayid.core :as sd]))
+
+(defn- duration
+  "The call's wall-clock duration in ms, when both timestamps are present."
+  [{:keys [started-at ended-at]}]
+  (when (and started-at ended-at)
+    (- ended-at started-at)))
+
+(defn node->data
+  "Project one recorded node onto plain data: its function or expression, the
+  captured argument and return (or throw) values kept *live*, its timing and
+  source location, and its children.  Internal bookkeeping (paths, depth, raw
+  timestamps, var metadata) is dropped."
+  [node]
+  (let [m (:meta node)]
+    (cond-> {:id (:id node)
+             :name (:name node)
+             :children (mapv node->data (:children node))}
+      (contains? node :args)    (assoc :args (:args node))
+      (:arg-map node)           (assoc :arg-map (:arg-map node))
+      (:form node)              (assoc :form (:form node))
+      (:inner-tags node)        (assoc :inner-tags (:inner-tags node))
+      (contains? node :return)  (assoc :return (:return node))
+      (:throw node)             (assoc :throw (:throw node))
+      (duration node)           (assoc :ms (duration node))
+      (:line m)                 (assoc :source (select-keys m [:file :line])))))
+
+(defn trace-data
+  "The active workspace's recorded call trees (or workspace W's) as plain,
+  navigable Clojure data - a vector of root calls, each with live captured
+  values.  This is the scripting entry point: `(->> (trace-data) (mapcat ...) ...)`."
+  [& [w]]
+  (mapv node->data (:children (if w (sd/ws-deref! w) (sd/ws-deref!)))))
+
+(defn tap-trace!
+  "`tap>` the recorded trace as data, for exploring in Portal / Reveal / Morse.
+  Returns the number of root calls tapped."
+  [& [w]]
+  (let [d (trace-data w)]
+    (tap> d)
+    (count d)))

--- a/test/sayid/data_test.clj
+++ b/test/sayid/data_test.clj
@@ -1,0 +1,50 @@
+(ns sayid.data-test
+  (:require [clojure.test :as t]
+            [sayid.core :as sd]
+            [sayid.data :as data]
+            [sayid.inner-corpus :as c]))
+
+(defn- fixture [f]
+  (with-out-str (sd/ws-reset!))
+  (f)
+  (with-out-str (sd/ws-reset!)))
+
+(t/use-fixtures :each fixture)
+
+(t/deftest trace-data-keeps-live-values
+  (sd/ws-add-trace-ns! sayid.inner-corpus)
+  (c/nested-calls 1 2)
+  (let [d (data/trace-data)
+        root (first d)]
+    (t/is (= 1 (count d)))
+    (t/testing "keyword keys and live (not pr-str'd) captured values"
+      (t/is (= 'sayid.inner-corpus/nested-calls (:name root)))
+      (t/is (= [1 2] (:args root)))
+      (t/is (= 1 (:return root))))
+    (t/testing "the nested calls come through as children"
+      (t/is (= '[sayid.inner-corpus/threaded sayid.inner-corpus/arith]
+               (map :name (:children root)))))
+    (t/testing "timing and source location are surfaced"
+      (t/is (number? (:ms root)))
+      (t/is (= "sayid/inner_corpus.clj" (get-in root [:source :file]))))))
+
+(t/deftest trace-data-includes-inner-expression-values
+  (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)
+  (c/arith 6 7)
+  (let [root (first (data/trace-data))
+        forms (map :form (:children root))]
+    (t/is (= '[(+ a b) (> s 10) (* s 2)] forms))
+    (t/is (= [13 true 26] (map :return (:children root))))))
+
+(t/deftest tap-trace-taps-the-data
+  (let [p (promise)
+        tapfn (fn [x] (deliver p x))]
+    (add-tap tapfn)
+    (try
+      (sd/ws-add-trace-ns! sayid.inner-corpus)
+      (c/nested-calls 1 2)
+      (t/is (= 1 (data/tap-trace!)))
+      (let [tapped (deref p 2000 ::timeout)]
+        (t/is (not= ::timeout tapped) "tap> delivered")
+        (t/is (= 'sayid.inner-corpus/nested-calls (-> tapped first :name))))
+      (finally (remove-tap tapfn)))))


### PR DESCRIPTION
More initiative 5, extending the data-first reach. There was no clean *programmatic* trace-as-data API - the nREPL `node->data` is string-keyed and `pr-str`'d for the wire, and private. `sayid.data` fills that gap with a projection built for scripting instead:

- `trace-data` returns the recorded call tree as a vector of root calls, keyword-keyed, with the captured argument/return values kept **live** (`:args [1 2]`, not `["1" "2"]`), plus `:ms` timing and `:source`. So `(->> (trace-data) (tree-seq :children :children) (filter slow?))` just works.
- `tap-trace!` `tap>`s it - exploring an execution in [Portal](https://github.com/djblue/portal)/Reveal/Morse is a one-liner, no Sayid-specific rendering. This is the "nearly free payoff" the roadmap called out for the data-first foundation.

With an inner trace the data carries the intermediate expression values too (`:form`/`:return` per node). Tests cover the projection (live values, children, timing, source), the inner-expression values, and that `tap>` actually delivers. Full matrix + kondo green.
