### PR TITLE
Add gold/diff-traces for comparing two executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Add `sayid.data`, the programmatic data-first API: `trace-data` returns the recorded call tree as plain keyword-keyed Clojure data with live captured values (and timing/source), and `tap-trace!` `tap>`s it for exploring in Portal/Reveal/Morse.
-* Add `sayid.golden`, a golden-trace testing helper: capture a run's recorded call tree as a normalized baseline and assert future runs still match it (`gold/matches-golden?`), with an update mode via `SAYID_GOLDEN_UPDATE`. With inner tracing the baseline covers intermediate expression values too.
+* Add `sayid.golden`, a golden-trace testing helper: capture a run's recorded call tree as a normalized baseline and assert future runs still match it (`gold/matches-golden?`), with an update mode via `SAYID_GOLDEN_UPDATE`. With inner tracing the baseline covers intermediate expression values too. Also `gold/diff-traces`, which structurally diffs two captured traces and reports exactly which calls and values changed.
 
 ## [0.6.0] - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,18 @@ later runs compare against it and fail with a diff when the execution changes.
 When a change is intentional, regenerate the goldens by running with
 `SAYID_GOLDEN_UPDATE=1` set (or `(binding [gold/*update* true] ...)`).
 
+For ad-hoc comparison there's `gold/diff-traces`, which structurally diffs two
+captured traces and reports exactly which calls and values changed - handy for
+confirming a refactor didn't alter behaviour:
+
+```clojure
+(def before (do (sd/ws-reset!) (sd/ws-add-trace-ns! my.ns) (my.ns/run) (gold/golden-trace)))
+;; ... change and reload my.ns ...
+(def after  (do (sd/ws-reset!) (sd/ws-add-trace-ns! my.ns) (my.ns/run) (gold/golden-trace)))
+
+(gold/diff-traces before after)   ; [] means the two runs executed identically
+```
+
 With an *inner* trace the golden captures the values *inside* each function too, so
 a baseline for `(fn [a b] (let [s (+ a b)] (if (> s 10) (* s 2) s)))` records
 `(+ a b) => 13`, `(> s 10) => true` and `(* s 2) => 26` - a regression net neither

--- a/src/sayid/golden.clj
+++ b/src/sayid/golden.clj
@@ -142,3 +142,58 @@
                     (println "  only in golden:" (pr-str (first diff)))
                     (println "  only in run:   " (pr-str (second diff)))
                     false))))
+
+;;; ---- comparing two traces ----------------------------------------------
+
+(def ^:private diff-fields [:name :args :form :return :throw :inner-tags])
+
+(defn- field-diffs
+  "Map of each differing field to its [in-a in-b] values."
+  [a b]
+  (reduce (fn [m k]
+            (if (= (get a k) (get b k))
+              m
+              (assoc m k [(get a k) (get b k)])))
+          {}
+          diff-fields))
+
+(defn- diff-node
+  "Diff two aligned nodes (either may be nil when a call is present in only one
+  run).  Returns `{:status :same}` when nothing under it changed, else a node
+  tagged :added / :removed / :changed with the differing fields and changed
+  children."
+  [a b]
+  (cond
+    (nil? a) {:status :added :name (:name b) :node b}
+    (nil? b) {:status :removed :name (:name a) :node a}
+    :else
+    (let [fd (field-diffs a b)
+          ca (:children a) cb (:children b)
+          kids (->> (range (max (count ca) (count cb)))
+                    (map #(diff-node (nth ca % nil) (nth cb % nil)))
+                    (remove (comp #{:same} :status))
+                    vec)]
+      (if (and (empty? fd) (empty? kids))
+        {:status :same}
+        (cond-> {:status :changed :name (:name a)}
+          (seq fd)   (assoc :changes fd)
+          (seq kids) (assoc :children kids))))))
+
+(defn diff-traces
+  "Structurally diff two normalized traces (as returned by `golden-trace`),
+  aligning calls by position.  Returns a pruned tree of just the differences: each
+  changed call with the fields that differ (`[in-a in-b]`) and its changed
+  children, and calls present in only one run tagged :added / :removed.  An empty
+  result means the two executions ran identically - which is a handy thing to
+  assert around a refactor:
+
+      (sd/ws-reset!) (sd/ws-add-trace-ns! my.ns) (my.ns/run)
+      (def before (gold/golden-trace))
+      ;; ... change the code, reload ...
+      (sd/ws-reset!) (sd/ws-add-trace-ns! my.ns) (my.ns/run)
+      (gold/diff-traces before (gold/golden-trace))   ; [] => behaviour unchanged"
+  [a b]
+  (->> (range (max (count a) (count b)))
+       (map #(diff-node (nth a % nil) (nth b % nil)))
+       (remove (comp #{:same} :status))
+       vec))

--- a/test/sayid/golden_test.clj
+++ b/test/sayid/golden_test.clj
@@ -49,3 +49,28 @@
   (sd/ws-add-inner-trace-fn! sayid.inner-corpus/arith)
   (c/arith 6 7)
   (t/is (gold/matches-golden? "arith-inner")))
+
+;;; ---- diffing two traces ------------------------------------------------
+
+(defn- trace-of [& args]
+  (with-out-str (sd/ws-reset!))
+  (sd/ws-add-trace-ns! sayid.inner-corpus)
+  (apply c/nested-calls args)
+  (gold/golden-trace))
+
+(t/deftest diff-traces-identical-is-empty
+  (t/is (= [] (gold/diff-traces (trace-of 1 2) (trace-of 1 2)))))
+
+(t/deftest diff-traces-pinpoints-changes
+  ;; nested-calls 1 2 vs 2 2: threaded [2 2 2] is identical either way, but arith
+  ;; is called with different args and nested-calls returns differently.
+  (let [d (gold/diff-traces (trace-of 1 2) (trace-of 2 2))
+        root (first d)]
+    (t/is (= 1 (count d)))
+    (t/is (= :changed (:status root)))
+    (t/testing "the top call's args and return changed"
+      (t/is (= [["1" "2"] ["2" "2"]] (get-in root [:changes :args])))
+      (t/is (= ["1" "2"] (get-in root [:changes :return]))))
+    (t/testing "only the arith child is reported as changed; threaded is pruned"
+      (t/is (= ["sayid.inner-corpus/arith"] (map :name (:children root))))
+      (t/is (= [["1" "0"] ["2" "0"]] (get-in root [:children 0 :changes :args]))))))


### PR DESCRIPTION
More initiative 5. `gold/diff-traces` is the interactive sibling of golden testing: rather than comparing a run against a stored baseline, it structurally diffs two captured traces against each other.

It aligns calls by position and returns a **pruned** tree of just the differences - each changed call with the fields that differ (`[in-a in-b]`) and its changed children, with calls present in only one run tagged `:added` / `:removed`. An empty result means the two runs executed identically:

```clojure
(def before (do (sd/ws-reset!) (sd/ws-add-trace-ns! my.ns) (my.ns/run) (gold/golden-trace)))
;; ... change and reload my.ns ...
(def after  (do (sd/ws-reset!) (sd/ws-add-trace-ns! my.ns) (my.ns/run) (gold/golden-trace)))
(gold/diff-traces before after)   ; [] => behaviour unchanged
```

That's a genuinely useful "did my refactor change how this runs?" check, and again something neither `tools.trace` nor a debugger offers. Reuses golden's normalization so the comparison is on the same stable printed values. Tests cover identical-is-empty and a case that pinpoints the changed call while pruning an unchanged sibling. Full matrix + kondo green.
