### PR TITLE
Add editor support for the trace-as-data functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Editor support for the new data functionality: `sayid-tap-trace` (`C-c s d t`) taps the workspace to your data tool, and `sayid-capture-baseline` (`C-c s d b`) / `sayid-diff-traces` (`C-c s d d`) drive the snapshot-then-compare flow. Backed by new `sayid-tap-trace`, `sayid-capture-baseline` and `sayid-diff-traces` nREPL ops.
 * Add `sayid.data`, the programmatic data-first API: `trace-data` returns the recorded call tree as plain keyword-keyed Clojure data with live captured values (and timing/source), and `tap-trace!` `tap>`s it for exploring in Portal/Reveal/Morse.
 * Add `sayid.golden`, a golden-trace testing helper: capture a run's recorded call tree as a normalized baseline and assert future runs still match it (`gold/matches-golden?`), with an update mode via `SAYID_GOLDEN_UPDATE`. With inner tracing the baseline covers intermediate expression values too. Also `gold/diff-traces`, which structurally diffs two captured traces and reports exactly which calls and values changed.
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ work on it:
 And since it's just data, exploring a trace in
 [Portal](https://github.com/djblue/portal), Reveal or Morse is a one-liner -
 `(sd-data/tap-trace!)` taps the whole tree to your data viewer of choice, no
-Sayid-specific rendering involved.
+Sayid-specific rendering involved. From the editor that's `C-c s d t`
+(`sayid-tap-trace`); `C-c s d b` then `C-c s d d` snapshot the current trace and
+diff a later run against it.
 
 ## Golden-trace testing
 
@@ -280,6 +282,9 @@ pop up the help buffer.
     C-c s t o -- Apply an outer trace to the symbol at point
     C-c s t r -- Remove existing trace from the symbol at point
     C-c s t K -- Remove all traces
+    C-c s d t -- Tap the recorded workspace to your data tool (Portal, Reveal, Morse)
+    C-c s d b -- Snapshot the current trace as a baseline for comparison
+    C-c s d d -- Diff the current trace against the baseline and tap the result
     C-c s c -- Clear the workspace trace log
     C-c s x -- Blow away workspace -- traces and logs
     C-c s s -- Popup buffer showing what it currently traced

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -810,6 +810,24 @@ manage traces)."
   (sayid--send-sync-request (list "op" "sayid-reset-workspace"))
   (message "Removed traces. Cleared log."))
 
+;;;###autoload
+(defun sayid-tap-trace ()
+  "Tap the recorded workspace to your data tool (Portal, Reveal, Morse)."
+  (interactive)
+  (sayid-send-and-message (list "op" "sayid-tap-trace")))
+
+;;;###autoload
+(defun sayid-capture-baseline ()
+  "Snapshot the current trace as the baseline for `sayid-diff-traces'."
+  (interactive)
+  (sayid-send-and-message (list "op" "sayid-capture-baseline")))
+
+;;;###autoload
+(defun sayid-diff-traces ()
+  "Diff the current trace against the captured baseline and tap the result."
+  (interactive)
+  (sayid-send-and-message (list "op" "sayid-diff-traces")))
+
 (defun sayid-find-existing-file (path)
   "Try to find a file at PATH, which may be absolute or relative.
 A relative PATH is resolved against the project's namespace source roots."
@@ -1014,6 +1032,9 @@ file can be found, jump to it."
     (define-key map (kbd "t o") 'sayid-outer-trace-fn)
     (define-key map (kbd "t r") 'sayid-remove-trace-fn)
     (define-key map (kbd "t K") 'sayid-kill-all-traces)
+    (define-key map (kbd "d t") 'sayid-tap-trace)
+    (define-key map (kbd "d b") 'sayid-capture-baseline)
+    (define-key map (kbd "d d") 'sayid-diff-traces)
     (define-key map (kbd "c")   'sayid-clear-log)
     (define-key map (kbd "x")   'sayid-reset-workspace)
     (define-key map (kbd "s")   'sayid-show-traced)

--- a/src/sayid/golden.clj
+++ b/src/sayid/golden.clj
@@ -197,3 +197,21 @@
        (map #(diff-node (nth a % nil) (nth b % nil)))
        (remove (comp #{:same} :status))
        vec))
+
+;;; ---- interactive baseline (for editor-driven diffing) ------------------
+
+(defonce ^:private baseline (atom nil))
+
+(defn capture-baseline!
+  "Snapshot the active workspace's normalized trace as the baseline that
+  `diff-from-baseline` compares against.  For the \"snapshot, change the code,
+  compare\" workflow.  Returns the number of root calls captured."
+  []
+  (count (reset! baseline (golden-trace))))
+
+(defn diff-from-baseline
+  "Diff the active workspace's trace against the last `capture-baseline!`
+  snapshot, or nil if no baseline has been captured yet."
+  []
+  (when-let [b @baseline]
+    (diff-traces b (golden-trace))))

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -11,6 +11,8 @@
    [clojure.tools.reader :as r]
    [clojure.tools.reader.reader-types :as rts]
    [sayid.core :as sd]
+   [sayid.data :as sd-data]
+   [sayid.golden :as gold]
    [sayid.query :as q]
    [sayid.string-output :as so]
    [sayid.trace :as tr]
@@ -466,6 +468,30 @@ or nil when nothing resolves there."
   [{:keys [transport] :as msg}]
   (sd/ws-reset!)
   (send-status-done msg))
+
+(defn ^:nrepl sayid-tap-trace
+  "tap> the recorded workspace as data, for exploring in Portal/Reveal/Morse."
+  [msg]
+  (reply:clj->nrepl msg (str "Tapped " (sd-data/tap-trace!) " call(s).")))
+
+(defn ^:nrepl sayid-capture-baseline
+  "Snapshot the current trace as the baseline for `sayid-diff-traces`."
+  [msg]
+  (reply:clj->nrepl msg (str "Captured baseline: " (gold/capture-baseline!)
+                             " call(s).")))
+
+(defn ^:nrepl sayid-diff-traces
+  "Diff the current trace against the captured baseline; tap the diff for
+  exploration and reply with a short summary."
+  [msg]
+  (let [d (gold/diff-from-baseline)]
+    (reply:clj->nrepl
+     msg
+     (cond
+       (nil? d)   "No baseline captured yet - use sayid-capture-baseline first."
+       (empty? d) "Traces are identical."
+       :else      (do (tap> d)
+                      (str (count d) " root call(s) differ; tapped the diff."))))))
 
 (defn ^:nrepl sayid-trace-all-ns-in-dir
   [{:keys [transport dir] :as msg}]

--- a/test/sayid/golden_test.clj
+++ b/test/sayid/golden_test.clj
@@ -74,3 +74,19 @@
     (t/testing "only the arith child is reported as changed; threaded is pruned"
       (t/is (= ["sayid.inner-corpus/arith"] (map :name (:children root))))
       (t/is (= [["1" "0"] ["2" "0"]] (get-in root [:children 0 :changes :args]))))))
+
+(t/deftest interactive-baseline-flow
+  (with-out-str (sd/ws-reset!))
+  (sd/ws-add-trace-ns! sayid.inner-corpus)
+  (c/nested-calls 1 2)
+  (t/is (= 1 (gold/capture-baseline!)) "captures the current trace as baseline")
+  (t/testing "an identical re-run diffs empty against the baseline"
+    (with-out-str (sd/ws-clear-log!))
+    (c/nested-calls 1 2)
+    (t/is (= [] (gold/diff-from-baseline))))
+  (t/testing "a changed re-run diffs against the baseline"
+    (with-out-str (sd/ws-clear-log!))
+    (c/nested-calls 2 2)
+    (let [d (gold/diff-from-baseline)]
+      (t/is (= 1 (count d)))
+      (t/is (= :changed (:status (first d)))))))


### PR DESCRIPTION
Editor support for the trace-as-data work (`sayid.data`, `diff-traces`), so it's usable from the client rather than only the REPL - the thing to land before tagging new releases.

- **`C-c s d t`** (`sayid-tap-trace`) - tap the recorded workspace to your data tool (Portal/Reveal/Morse).
- **`C-c s d b`** (`sayid-capture-baseline`) then **`C-c s d d`** (`sayid-diff-traces`) - the snapshot-then-compare flow: baseline the current trace, refactor, then diff a later run against it. The diff op taps the result for exploration and replies with a summary either way ("N root call(s) differ" / "Traces are identical").

Backed by three new `^:nrepl` ops and a small in-memory baseline in `sayid.golden` (`capture-baseline!` / `diff-from-baseline`).

Golden *testing* stays a test-file/CI workflow, so it deliberately gets no editor command.

Clojure suite (71), clj-kondo, and the elisp compile/lint/specs are all green; README keybinding table and changelog updated.
