### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## [0.7.1] - 2026-07-11
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ provides a very flexible Sayid API. Its ops are documented in
 
 Add this to the dependencies in your project.clj or lein profiles.clj:
 
-    [mx.cider/sayid "0.7.0"]
+    [mx.cider/sayid "0.7.1"]
 
 To use the bundled nREPL middleware, you'll want to include Sayid as a
 plug-in. Here's an example of a bare-bones profiles.clj that works for
 me:
 
 ```clojure
-{:user {:plugins [[mx.cider/sayid "0.7.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.7.1"]]}}
 ```
 
 ### Clojure CLI - deps.edn
@@ -96,7 +96,7 @@ tools.deps config directory (often `$HOME/.clojure`).
 
 ```clojure
 {:deps
-  {mx.cider/sayid {:mvn/version "0.7.0"}}}
+  {mx.cider/sayid {:mvn/version "0.7.1"}}}
 ```
 
 ### Emacs Integration
@@ -121,7 +121,7 @@ that works for me:
 
 ```clojure
 {:user {:plugins [[cider/cider-nrepl "0.59.0"]
-                  [mx.cider/sayid "0.7.0"]]
+                  [mx.cider/sayid "0.7.1"]]
         :dependencies [[nrepl/nrepl "1.3.1"]]}}
 ```
 

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -11,7 +11,7 @@ This document is the reference for that wire API.
 With Leiningen, add Sayid as a plugin (it registers the middleware automatically):
 
 ```clojure
-{:user {:plugins [[mx.cider/sayid "0.7.0"]]}}
+{:user {:plugins [[mx.cider/sayid "0.7.1"]]}}
 ```
 
 Or add the middleware explicitly when you start the server, e.g. with the
@@ -259,7 +259,7 @@ Remove all traces and clear the recorded calls. Takes no params. Replies
 
 ### `sayid-version`
 
-Replies with the Sayid version string (e.g. `"0.7.0"`).
+Replies with the Sayid version string (e.g. `"0.7.1"`).
 
 ### `sayid-get-trace-count`
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mx.cider/sayid "0.7.0"
+(defproject mx.cider/sayid "0.7.1"
   :description "Sayid is a library for debugging and profiling clojure code."
   :url "https://github.com/clojure-emacs/sayid"
   :scm {:name "git" :url "https://github.com/clojure-emacs/sayid"}

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -4,7 +4,7 @@
 
 ;; Author: Bill Piel <bill@billpiel.com>
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
-;; Version: 0.7.0
+;; Version: 0.7.1
 ;; URL: https://github.com/clojure-emacs/sayid
 ;; Package-Requires: ((emacs "28") (cider "1.23"))
 ;; Keywords: clojure, cider, debugger
@@ -51,11 +51,11 @@ The injected dependencies are most likely nREPL middlewares."
   :type 'boolean)
 
 (defconst sayid-version
-  "0.7.0"
+  "0.7.1"
   "The current version of sayid.")
 
 (defconst sayid-injected-plugin-version
-  "0.7.0"
+  "0.7.1"
   "The version of the sayid Lein plugin to be automatically injected.")
 
 (defface sayid-int-face '((t :inherit default))

--- a/src/sayid/core.clj
+++ b/src/sayid/core.clj
@@ -18,7 +18,7 @@
 
 (def version
   "The current version of sayid as a string."
-  "0.7.0")
+  "0.7.1")
 
 (def workspace
   "The active workspace. Used by default in any function prefixed `ws-`

--- a/src/sayid/plugin.clj
+++ b/src/sayid/plugin.clj
@@ -2,7 +2,7 @@
 
 (def version
   "The current version of sayid as a string."
-  "0.7.0")
+  "0.7.1")
 
 (defn middleware
   [project]


### PR DESCRIPTION
A patch release with two bug fixes to the recording/shelf machinery, both surfaced while documenting those features:

- The workspace shelf (`ws-save!`/`ws-load!`) shelved a live reference instead of a snapshot, so mutating the workspace after saving corrupted the stored copy. It now snapshots, like recordings do.
- `rec-save-as!` reported `id 'null' to slot 'null'` (it read the atom, not its value).

Deploy (dual-coordinate Clojars) and tagging happen after this merges.