### PR TITLE
Make the Emacs client easier to pick up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `sayid-menu`, a transient menu that `sayid-setup-package` now binds to the `C-c s` prefix: commands grouped by workflow, with live traced/recorded state in the header (backed by a new `sayid-get-log-count` op). All classic key sequences keep working - the menu uses the same keys - and `sayid-use-menu` set to nil restores the plain prefix keymap.
 * An empty workspace tree (`C-c s w`) and an empty traced-functions view (`C-c s s`) now render a short getting-started hint instead of signaling an error.
 * The trace commands describe their outcome in plain language (what was traced and what to do next) instead of echoing the raw server reply, and enabling/disabling an untraced function now reports the actual problem. The `sayid-trace-fn-at-point` op reply changed accordingly (see `doc/nrepl-api.md`).
 * Tracing a function no longer pops up the traced-functions window; it's refreshed only when already visible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changes
 
+* An empty workspace tree (`C-c s w`) and an empty traced-functions view (`C-c s s`) now render a short getting-started hint instead of signaling an error.
+
+### Changes
+
 * Require CIDER 2.0.
 
 ### Bugs fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Changes
 
 * An empty workspace tree (`C-c s w`) and an empty traced-functions view (`C-c s s`) now render a short getting-started hint instead of signaling an error.
+* The trace commands describe their outcome in plain language (what was traced and what to do next) instead of echoing the raw server reply, and enabling/disabling an untraced function now reports the actual problem. The `sayid-trace-fn-at-point` op reply changed accordingly (see `doc/nrepl-api.md`).
+* Tracing a function no longer pops up the traced-functions window; it's refreshed only when already visible.
+* `g` refreshes the workspace tree and traced-functions buffers.
+* `sayid-reset-workspace` asks for confirmation, since it irreversibly drops all traces and the whole recording.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * `sayid-reset-workspace` asks for confirmation, since it irreversibly drops all traces and the whole recording.
 * Add `sayid-trace-fn` (`C-c s t t`), the just-trace-this command for newcomers - an outer trace of the function at point.
 * Rename the per-function trace commands for consistency: `sayid-trace-fn-outer`, `sayid-trace-fn-inner` and `sayid-trace-fn-remove` (the old `sayid-outer-trace-fn`, `sayid-inner-trace-fn` and `sayid-remove-trace-fn` names remain as obsolete aliases).
+* Bring the workspace tree view to feature parity with the legacy text view: `c d` defs a captured value to `$s/*`, `c p` pretty-prints one, and `c r` copies an expression reproducing the call at point.
+* `sayid-query-form-at-point` (`C-c s f`) now renders its results in the tree view, backed by the new `sayid-query-form-at-point-data` op, instead of the legacy text view.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Tracing a function no longer pops up the traced-functions window; it's refreshed only when already visible.
 * `g` refreshes the workspace tree and traced-functions buffers.
 * `sayid-reset-workspace` asks for confirmation, since it irreversibly drops all traces and the whole recording.
+* Add `sayid-trace-fn` (`C-c s t t`), the just-trace-this command for newcomers - an outer trace of the function at point.
+* Rename the per-function trace commands for consistency: `sayid-trace-fn-outer`, `sayid-trace-fn-inner` and `sayid-trace-fn-remove` (the old `sayid-outer-trace-fn`, `sayid-inner-trace-fn` and `sayid-remove-trace-fn` names remain as obsolete aliases).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@
 * Rename the per-function trace commands for consistency: `sayid-trace-fn-outer`, `sayid-trace-fn-inner` and `sayid-trace-fn-remove` (the old `sayid-outer-trace-fn`, `sayid-inner-trace-fn` and `sayid-remove-trace-fn` names remain as obsolete aliases).
 * Bring the workspace tree view to feature parity with the legacy text view: `c d` defs a captured value to `$s/*`, `c p` pretty-prints one, and `c r` copies an expression reproducing the call at point.
 * `sayid-query-form-at-point` (`C-c s f`) now renders its results in the tree view, backed by the new `sayid-query-form-at-point-data` op, instead of the legacy text view.
-
-### Changes
-
 * Require CIDER 2.0.
 
 ### Bugs fixed

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ somewhere, to load keybindings for clojure-mode buffers.
   (sayid-setup-package))
 ```
 
+This binds `C-c s` to the Sayid menu (`sayid-menu`), a transient popup
+showing the commands grouped by workflow, plus live state about what's
+traced and recorded. The menu uses real key sequences, so `C-c s t b`
+does the same thing whether you read it off the menu or type it blind.
+Prefer the classic prefix keymap without a popup? Set `sayid-use-menu`
+to nil before calling `sayid-setup-package`.
+
 If you use CIDER's jack-in commands, then Sayid automatically adds the
 Maven dependency when starting a REPL. This means you don't need to
 manually add the dependency to your `project.clj` or `deps.edn` file.
@@ -344,15 +351,15 @@ a baseline for `(fn [a b] (let [s (+ a b)] (if (> s 10) (* s 2) s)))` records
 > [!NOTE]
 > This section assumes you're using the official CIDER plugin.
 
-The keybindings are grouped by buffer below. Every list is also available
-from within Emacs: press `h` in any Sayid buffer (or `C-c s h` in a Clojure
-buffer) to pop up the matching help buffer.
+The basic loop is: **trace** something, **run** the code that hits it, then
+**explore** what was recorded. In a Clojure buffer press `C-c s` to pop up
+the Sayid menu - it groups the commands along that loop and shows how much
+is traced and recorded right now. The keybindings are also listed by buffer
+below, and every list is available from within Emacs: press `h` in any
+Sayid buffer to pop up the matching help buffer.
 
 API docs for the core namespaces are available on
 [cljdoc](https://cljdoc.org/d/mx.cider/sayid/CURRENT).
-
-In a clojure-mode buffer, press `C-c s h` (`sayid-show-help`) to
-pop up the help buffer.
 
     C-c s f -- Show the recorded calls of the form at point as a tree
     C-c s ! -- Disable traces, load the current buffer, enable traces, and clear the workspace log

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ pop up the help buffer.
     C-c s f -- Queries the active workspace for entries that most closely match the context of the cursor position
     C-c s ! -- Disable traces, load the current buffer, enable traces, and clear the workspace log
     C-c s w -- Show the recorded workspace as a navigable, foldable tree
+    C-c s t t -- Trace the function at point (start here)
     C-c s t y -- Prompts for a dir, recursively traces all ns's in that dir and subdirs
     C-c s t p -- Prompts for a pattern (* = wildcard), and applies a trace to all *loaded* ns's whose name matches the pattern
     C-c s t b -- Trace the ns in the current buffer

--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ few actions on top:
     TAB -- fold or unfold the call at point
     RET, . -- jump to the call's source
     n, p -- move to the next / previous call
+    g -- refresh the current view (re-runs its query)
     f -- show every recorded call of the function at point (prefix: a modifier)
     i -- focus the call at point and its subtree (prefix: ancestors/descendants)
     c i -- inspect a captured value in CIDER's inspector (prefix: pick which)
@@ -402,9 +403,9 @@ own keybinding help.
 
 `C-c s s` (`sayid-show-traced`) shows what's traced as a namespaces to functions
 tree in the `*sayid-traced*` buffer. `RET` on a function jumps to its source;
-`TAB` folds a namespace, `n`/`p` move, `q` quits. `e`/`d`/`r` enable, disable and
-remove the trace at point, and `i`/`o` switch a function to an inner or outer
-trace.
+`TAB` folds a namespace, `n`/`p` move, `g` refreshes, `q` quits. `e`/`d`/`r`
+enable, disable and remove the trace at point, and `i`/`o` switch a function to
+an inner or outer trace.
 
 
 In the `*sayid-pprint*` buffer, press `h` to pop up the help

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ API docs for the core namespaces are available on
 In a clojure-mode buffer, press `C-c s h` (`sayid-show-help`) to
 pop up the help buffer.
 
-    C-c s f -- Queries the active workspace for entries that most closely match the context of the cursor position
+    C-c s f -- Show the recorded calls of the form at point as a tree
     C-c s ! -- Disable traces, load the current buffer, enable traces, and clear the workspace log
     C-c s w -- Show the recorded workspace as a navigable, foldable tree
     C-c s t t -- Trace the function at point (start here)
@@ -391,15 +391,15 @@ few actions on top:
     f -- show every recorded call of the function at point (prefix: a modifier)
     i -- focus the call at point and its subtree (prefix: ancestors/descendants)
     c i -- inspect a captured value in CIDER's inspector (prefix: pick which)
+    c d -- def a captured value to $s/* for the REPL (prefix: pick which)
+    c p -- pretty-print a captured value (prefix: pick which)
+    c r -- copy an expression that reproduces the call at point
     w -- back to the full workspace
     q -- quit the window
 
-The older text-rendered view is still available (`M-x sayid-get-workspace`, and
-where the pretty-print and query-at-point commands land); press `h` in it for its
-own keybinding help.
-    g -- generate instance expression and put in kill ring
-    h -- help
-    q -- quit window
+The legacy text-rendered view (`M-x sayid-get-workspace`) is still around but
+no longer where any default binding lands; press `h` in it for its keybinding
+help.
 
 
 `C-c s s` (`sayid-show-traced`) shows what's traced as a namespaces to functions

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -64,12 +64,14 @@ Apply a trace action to the function whose symbol is at the cursor.
 | `line`, `column` | 1-based cursor position |
 | `source` | the buffer's full text |
 
-Replies with a map describing the outcome, so clients can report it truthfully:
-`sym` is the resolved qualified symbol (e.g. `"my.ns/my-fn"`) and `was-traced`
-(`0`/`1`) says whether the function was traced before the action. When nothing
-resolves at that position the reply is an empty map. `enable`, `disable` and
-`remove` are only applied when the function was traced; `add-outer`/`add-inner`
-always apply.
+The reply's `value` is the resolved qualified symbol (e.g. `"my.ns/my-fn"`), or
+an empty string when nothing resolves at that position - the shape older
+clients expect. The outcome details ride along as extra response slots: `sym`
+(the same symbol) and `was-traced` (`0`/`1`, whether the function was traced
+before the action), so a current client can report the outcome truthfully.
+`enable` and `disable` are only applied when the function was traced;
+`add-outer`, `add-inner` and `remove` always apply (`remove` doubles as the
+reconciliation path for a trace that fell out of sync with the workspace).
 
 ### `sayid-query-form-at-point-data`
 

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -284,6 +284,11 @@ Replies with the number of traces in the workspace.
 
 Replies with the number of currently enabled traces.
 
+### `sayid-get-log-count`
+
+Replies with the number of top-level calls currently recorded in the
+workspace.
+
 ### `sayid-get-meta-at-point`
 
 Resolve the symbol at the cursor and report its metadata. Params: `source`,

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -71,6 +71,17 @@ resolves at that position the reply is an empty map. `enable`, `disable` and
 `remove` are only applied when the function was traced; `add-outer`/`add-inner`
 always apply.
 
+### `sayid-query-form-at-point-data`
+
+Data counterpart of `sayid-query-form-at-point`: replies with the recorded
+calls whose source position matches `file`/`line`, as a list of call nodes
+(the `sayid-get-workspace-data` shape).
+
+| param | meaning |
+|-------|---------|
+| `file` | path of the buffer's file |
+| `line` | 1-based cursor line |
+
 ### `sayid-trace-fn`
 
 Apply a trace action to an explicitly named function.

--- a/doc/nrepl-api.md
+++ b/doc/nrepl-api.md
@@ -64,8 +64,12 @@ Apply a trace action to the function whose symbol is at the cursor.
 | `line`, `column` | 1-based cursor position |
 | `source` | the buffer's full text |
 
-Replies with the resolved qualified symbol (e.g. `"my.ns/my-fn"`), or `nil` when
-nothing resolves at that position.
+Replies with a map describing the outcome, so clients can report it truthfully:
+`sym` is the resolved qualified symbol (e.g. `"my.ns/my-fn"`) and `was-traced`
+(`0`/`1`) says whether the function was traced before the action. When nothing
+resolves at that position the reply is an empty map. `enable`, `disable` and
+`remove` are only applied when the function was traced; `add-outer`/`add-inner`
+always apply.
 
 ### `sayid-trace-fn`
 

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -329,47 +329,83 @@ state.  POS is the position to move cursor to."
                                 "file" (buffer-file-name)
                                 "line" (line-number-at-pos))))
 
-(defun sayid--trace-fn-at-point (action fail-msg)
-  "Apply trace ACTION to the fn at point, reporting FAIL-MSG when none resolves.
-Refreshes the traced-functions view afterwards."
-  (sayid-send-and-message (list "op" "sayid-trace-fn-at-point"
-                                "action" action
-                                "file" (buffer-file-name)
-                                "line" (line-number-at-pos)
-                                "column" (+ (current-column) 1)
-                                "source" (buffer-string))
-                          fail-msg)
-  (sayid-show-traced))
+(defun sayid--key-hint (command)
+  "Return a human-readable way to invoke COMMAND.
+Prefers the real keybinding in `clojure-mode-map' (where
+`sayid-setup-package' installs the Sayid keys); falls back to naming
+the command."
+  (let ((key (where-is-internal command (list clojure-mode-map) t)))
+    (if key
+        (key-description key)
+      (format "M-x %s" command))))
+
+(defun sayid--refresh-traced-if-visible ()
+  "Refresh the traced-functions view when its buffer is visible."
+  (when (get-buffer-window "*sayid-traced*" 'visible)
+    (save-selected-window (sayid-show-traced))))
+
+(defun sayid--trace-fn-at-point (action)
+  "Apply trace ACTION to the function at point and describe the outcome.
+Refreshes the traced-functions view when it is visible."
+  (let* ((resp (sayid-req-get-value (list "op" "sayid-trace-fn-at-point"
+                                          "action" action
+                                          "file" (buffer-file-name)
+                                          "line" (line-number-at-pos)
+                                          "column" (+ (current-column) 1)
+                                          "source" (buffer-string))))
+         (sym (and resp (nrepl-dict-get resp "sym")))
+         (was-traced (and resp (eql 1 (nrepl-dict-get resp "was-traced")))))
+    (unless sym
+      (user-error "No function at point - put the cursor on a function name"))
+    (cond
+     ((member action '("add-outer" "add-inner"))
+      (let ((kind (if (string= action "add-outer") "outer" "inner")))
+        (if was-traced
+            (message "Switched %s to an %s trace" sym kind)
+          (message "%s-traced %s - run some code, then `%s' shows what was recorded"
+                   (capitalize kind) sym
+                   (sayid--key-hint #'sayid-tree-view-workspace)))))
+     ((not was-traced)
+      (user-error "%s isn't traced - trace it first with `%s'"
+                  sym (sayid--key-hint #'sayid-outer-trace-fn)))
+     (t
+      (message "%s the trace on %s"
+               (pcase action
+                 ("enable" "Enabled")
+                 ("disable" "Disabled")
+                 ("remove" "Removed"))
+               sym)))
+    (sayid--refresh-traced-if-visible)))
 
 ;;;###autoload
 (defun sayid-trace-fn-enable ()
-  "Enable tracing for symbol at point.  Symbol should point to a fn var."
+  "Enable the existing (disabled) trace of the function at point."
   (interactive)
-  (sayid--trace-fn-at-point "enable" "Nothing traced. Make sure cursor is on symbol."))
+  (sayid--trace-fn-at-point "enable"))
 
 ;;;###autoload
 (defun sayid-trace-fn-disable ()
-  "Disable tracing for symbol at point.  Symbol should point to a fn var."
+  "Disable the trace of the function at point, keeping it in the trace set."
   (interactive)
-  (sayid--trace-fn-at-point "disable" "Nothing found. Make sure cursor is on symbol."))
+  (sayid--trace-fn-at-point "disable"))
 
 ;;;###autoload
 (defun sayid-outer-trace-fn ()
-  "Add outer tracing for symbol at point.  Symbol should point to a fn var."
+  "Trace the function at point, recording its arguments and return value."
   (interactive)
-  (sayid--trace-fn-at-point "add-outer" "Nothing traced. Make sure cursor is on symbol."))
+  (sayid--trace-fn-at-point "add-outer"))
 
 ;;;###autoload
 (defun sayid-inner-trace-fn ()
-  "Add inner tracing for symbol at point.  Symbol should point to a fn var."
+  "Inner-trace the function at point, also recording its inner expressions."
   (interactive)
-  (sayid--trace-fn-at-point "add-inner" "Nothing traced. Make sure cursor is on symbol."))
+  (sayid--trace-fn-at-point "add-inner"))
 
 ;;;###autoload
 (defun sayid-remove-trace-fn ()
-  "Remove tracing for symbol at point.  Symbol should point to a fn var."
+  "Remove the trace of the function at point."
   (interactive)
-  (sayid--trace-fn-at-point "remove" "Nothing found. Make sure cursor is on symbol."))
+  (sayid--trace-fn-at-point "remove"))
 
 ;;;###autoload
 (defun sayid-load-enable-clear ()
@@ -576,20 +612,30 @@ To record something:
      (`C-c s t b') traces the current buffer's namespace.
   2. Run some code that calls what you traced (eval a form,
      run a test, hit an endpoint).
-  3. View the recording with `sayid-tree-view-workspace' (`C-c s w').
+  3. Refresh this buffer with `g' (or `C-c s w' from anywhere).
 "
   "What to show in the workspace tree buffer when nothing was recorded.")
 
-(defun sayid-tree--render (roots title &optional empty-hint)
+(defvar-local sayid-tree--refresh-fn nil
+  "Function of no arguments that re-runs the fetch that produced this tree.")
+
+(defun sayid-tree--render (roots title &optional empty-hint refresh-fn)
   "Render ROOTS, a list of `sayid-get-workspace-data' nodes, as a tree.
 TITLE is shown in the header line.  When ROOTS is empty, show EMPTY-HINT
-\(a string) instead of a blank buffer."
+\(a string) instead of a blank buffer.  REFRESH-FN, when non-nil, is stored
+so `sayid-tree-refresh' can re-run the fetch that produced this tree."
   (with-current-buffer (cider-popup-buffer "*sayid-tree*" 'select
                                            'sayid-tree-mode 'ancillary)
+    (setq-local sayid-tree--refresh-fn refresh-fn)
     (cider-tree-view-render (mapcar #'sayid-tree--make-node roots) title
                             (when (and empty-hint (null roots))
                               (lambda ()
                                 (insert (propertize empty-hint 'face 'shadow)))))))
+
+(defun sayid-tree-refresh ()
+  "Re-run the query that produced this tree buffer and re-render it."
+  (interactive)
+  (funcall (or sayid-tree--refresh-fn #'sayid-tree-view-workspace)))
 
 (defun sayid-tree--query-title (kind selector mod)
   "Build a tree title for a query of KIND on SELECTOR with modifier MOD."
@@ -615,32 +661,42 @@ a named argument."
                      (user-error "This call has no return value to inspect")))))
     (sayid--inspect-value (nrepl-dict-get call "id") path)))
 
+(defun sayid-tree--show-fn-query (fn-name mod)
+  "Fetch and render every recorded call of FN-NAME, with query modifier MOD."
+  (let ((roots (sayid-req-get-value (list "op" "sayid-query-by-fn-data"
+                                          "fn-name" fn-name
+                                          "mod" mod))))
+    (if roots
+        (sayid-tree--render roots (sayid-tree--query-title "fn" fn-name mod)
+                            nil
+                            (lambda () (sayid-tree--show-fn-query fn-name mod)))
+      (user-error "No recorded calls of %s" fn-name))))
+
 (defun sayid-tree-query-fn (&optional arg)
   "Re-render the tree with every recorded call of the function at point.
 With a prefix ARG, also prompt for a query modifier."
   (interactive "P")
-  (let* ((fn-name (nrepl-dict-get (sayid-tree--call-at-point) "name"))
-         (mod (sayid--read-query-mod arg))
-         (roots (sayid-req-get-value (list "op" "sayid-query-by-fn-data"
-                                           "fn-name" fn-name
-                                           "mod" mod))))
+  (sayid-tree--show-fn-query (nrepl-dict-get (sayid-tree--call-at-point) "name")
+                             (sayid--read-query-mod arg)))
+
+(defun sayid-tree--show-id-query (id mod)
+  "Fetch and render the recorded call ID and its subtree, with modifier MOD."
+  (let ((roots (sayid-req-get-value (list "op" "sayid-query-by-id-data"
+                                          "trace-id" id
+                                          "mod" mod))))
     (if roots
-        (sayid-tree--render roots (sayid-tree--query-title "fn" fn-name mod))
-      (user-error "No recorded calls of %s" fn-name))))
+        (sayid-tree--render roots (sayid-tree--query-title "id" id mod)
+                            nil
+                            (lambda () (sayid-tree--show-id-query id mod)))
+      (user-error "Call %s not found" id))))
 
 (defun sayid-tree-query-id (&optional arg)
   "Re-render the tree focused on the call at point.
 With a prefix ARG, also prompt for a query modifier (e.g. \"a\" for ancestors,
 \"d\" for descendants, optionally with a depth)."
   (interactive "P")
-  (let* ((id (nrepl-dict-get (sayid-tree--call-at-point) "id"))
-         (mod (sayid--read-query-mod arg))
-         (roots (sayid-req-get-value (list "op" "sayid-query-by-id-data"
-                                           "trace-id" id
-                                           "mod" mod))))
-    (if roots
-        (sayid-tree--render roots (sayid-tree--query-title "id" id mod))
-      (user-error "Call %s not found" id))))
+  (sayid-tree--show-id-query (nrepl-dict-get (sayid-tree--call-at-point) "id")
+                             (sayid--read-query-mod arg)))
 
 ;;;###autoload
 (defun sayid-tree-view-workspace ()
@@ -650,11 +706,13 @@ When nothing has been recorded yet the buffer explains how to get going.
 See `sayid-tree-mode' for the keys available in the tree buffer."
   (interactive)
   (let ((roots (sayid-req-get-value (list "op" "sayid-get-workspace-data"))))
-    (sayid-tree--render roots "Sayid workspace" sayid-tree--empty-workspace-hint)))
+    (sayid-tree--render roots "Sayid workspace" sayid-tree--empty-workspace-hint
+                        #'sayid-tree-view-workspace)))
 
 (defvar sayid-tree-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "f")   #'sayid-tree-query-fn)
+    (define-key map (kbd "g")   #'sayid-tree-refresh)
     (define-key map (kbd "i")   #'sayid-tree-query-id)
     (define-key map (kbd "w")   #'sayid-tree-view-workspace)
     (define-key map (kbd "c i") #'sayid-tree-inspect)
@@ -666,7 +724,8 @@ See `sayid-tree-mode' for the keys available in the tree buffer."
 Inherits navigation and folding from `cider-tree-view-mode' and adds Sayid
 actions: \\<sayid-tree-mode-map>\\[sayid-tree-query-fn] query the function at
 point, \\[sayid-tree-query-id] focus the call at point, \\[sayid-tree-inspect]
-inspect a value, \\[sayid-tree-view-workspace] back to the full workspace.")
+inspect a value, \\[sayid-tree-refresh] refresh the current view,
+\\[sayid-tree-view-workspace] back to the full workspace.")
 
 (defun sayid-traced--fn-node (fn)
   "Make a `cider-tree-view-node' for a traced-function dict FN.
@@ -736,6 +795,7 @@ namespace-level op (only meaningful for enable, disable and remove)."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "e") #'sayid-traced-enable)
     (define-key map (kbd "d") #'sayid-traced-disable)
+    (define-key map (kbd "g") #'sayid-traced-refresh)
     (define-key map (kbd "r") #'sayid-traced-remove)
     (define-key map (kbd "i") #'sayid-traced-inner-trace)
     (define-key map (kbd "o") #'sayid-traced-outer-trace)
@@ -748,7 +808,7 @@ Inherits navigation and folding from `cider-tree-view-mode' and adds trace
 management: \\<sayid-traced-tree-mode-map>\\[sayid-traced-enable] enable,
 \\[sayid-traced-disable] disable, \\[sayid-traced-remove] remove,
 \\[sayid-traced-inner-trace] inner-trace, \\[sayid-traced-outer-trace]
-outer-trace the entry at point.")
+outer-trace the entry at point, \\[sayid-traced-refresh] refresh the view.")
 
 (defconst sayid-traced--empty-hint
   "Nothing is traced yet.
@@ -760,17 +820,28 @@ recording with `sayid-tree-view-workspace' (`C-c s w').
 "
   "What to show in the traced-functions buffer when nothing is traced.")
 
-(defun sayid-traced--render (groups)
+(defvar-local sayid-traced--ns nil
+  "The namespace filter this traced-functions buffer was rendered with.")
+
+(defun sayid-traced--render (groups ns)
   "Render GROUPS, a list of `sayid-show-traced-data' namespace groups.
-When GROUPS is empty, show a hint on how to trace something instead."
+NS is the namespace filter the groups were fetched with (nil for all),
+remembered so `sayid-traced-refresh' can re-run the same fetch.  When
+GROUPS is empty, show a hint on how to trace something instead."
   (with-current-buffer (cider-popup-buffer "*sayid-traced*" 'select
                                            'sayid-traced-tree-mode 'ancillary)
+    (setq-local sayid-traced--ns ns)
     (cider-tree-view-render (mapcar #'sayid-traced--ns-node groups)
                             "Traced functions"
                             (unless groups
                               (lambda ()
                                 (insert (propertize sayid-traced--empty-hint
                                                     'face 'shadow)))))))
+
+(defun sayid-traced-refresh ()
+  "Re-fetch and re-render the traced-functions view."
+  (interactive)
+  (sayid-show-traced sayid-traced--ns))
 
 ;;;###autoload
 (defun sayid-show-traced (&optional ns)
@@ -782,7 +853,8 @@ manage traces)."
   (interactive)
   (sayid-traced--render (sayid-req-get-value
                          (append (list "op" "sayid-show-traced-data")
-                                 (when ns (list "ns" ns))))))
+                                 (when ns (list "ns" ns))))
+                        ns))
 
 ;;;###autoload
 (defun sayid-show-traced-ns ()
@@ -847,10 +919,12 @@ manage traces)."
 
 ;;;###autoload
 (defun sayid-reset-workspace ()
-  "Reset all traces and log in workspace."
+  "Reset the workspace: remove all traces and the whole recording.
+Asks for confirmation first, since there is no way back."
   (interactive)
-  (sayid--send-sync-request (list "op" "sayid-reset-workspace"))
-  (message "Removed traces. Cleared log."))
+  (when (y-or-n-p "Reset the Sayid workspace (removes all traces and the recording)? ")
+    (sayid--send-sync-request (list "op" "sayid-reset-workspace"))
+    (message "Removed traces. Cleared log.")))
 
 ;;;###autoload
 (defun sayid-tap-trace ()

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -316,16 +316,12 @@ state.  POS is the position to move cursor to."
 
 (defun sayid-tree--show-form-query (file line)
   "Fetch and render every recorded call of the form at FILE and LINE as a tree."
-  (let ((roots (sayid-req-get-value (list "op" "sayid-query-form-at-point-data"
-                                          "file" file
-                                          "line" line))))
-    (if roots
-        (sayid-tree--render roots
-                            (format "Query: %s:%s"
-                                    (file-name-nondirectory file) line)
-                            nil
-                            (lambda () (sayid-tree--show-form-query file line)))
-      (user-error "No recorded calls for the form at point"))))
+  (sayid-tree--show-query
+   (lambda () (sayid-req-get-value (list "op" "sayid-query-form-at-point-data"
+                                         "file" file
+                                         "line" line)))
+   (format "Query: %s:%s" (file-name-nondirectory file) line)
+   "No recorded calls for the form at point"))
 
 ;;;###autoload
 (defun sayid-query-form-at-point ()
@@ -363,9 +359,12 @@ to naming the command."
      (t (format "M-x %s" command)))))
 
 (defun sayid--refresh-traced-if-visible ()
-  "Refresh the traced-functions view when its buffer is visible."
-  (when (get-buffer-window "*sayid-traced*" 'visible)
-    (save-selected-window (sayid-show-traced))))
+  "Refresh the traced-functions view when its buffer is visible.
+Preserves the namespace filter the view was rendered with."
+  (when-let* ((win (get-buffer-window "*sayid-traced*" 'visible)))
+    (save-selected-window
+      (sayid-show-traced
+       (buffer-local-value 'sayid-traced--ns (window-buffer win))))))
 
 (defun sayid--trace-fn-at-point (action)
   "Apply trace ACTION to the function at point and describe the outcome.
@@ -651,19 +650,23 @@ the thrown error, or a named argument."
                   (user-error "No call at point"))))
     (cider-tree-view-node-value node)))
 
-(defconst sayid-tree--empty-workspace-hint
-  "The workspace is empty - Sayid hasn't recorded any calls yet.
+(defun sayid-tree--empty-workspace-hint ()
+  "Build the hint shown in the workspace tree when nothing was recorded.
+The key sequences are looked up live, so a custom prefix shows correctly."
+  (format "The workspace is empty - Sayid hasn't recorded any calls yet.
 
 To record something:
 
-  1. Trace what you're interested in: `sayid-trace-fn' (`C-c s t t')
+  1. Trace what you're interested in: `sayid-trace-fn' (`%s')
      traces the function at point, `sayid-trace-ns-in-file'
-     (`C-c s t b') the current buffer's whole namespace.
+     (`%s') the current buffer's whole namespace.
   2. Run some code that calls what you traced (eval a form,
      run a test, hit an endpoint).
-  3. Refresh this buffer with `g' (or `C-c s w' from anywhere).
+  3. Refresh this buffer with `g' (or `%s' from anywhere).
 "
-  "What to show in the workspace tree buffer when nothing was recorded.")
+          (sayid--key-hint #'sayid-trace-fn)
+          (sayid--key-hint #'sayid-trace-ns-in-file)
+          (sayid--key-hint #'sayid-tree-view-workspace)))
 
 (defvar-local sayid-tree--refresh-fn nil
   "Function of no arguments that re-runs the fetch that produced this tree.")
@@ -685,6 +688,30 @@ so `sayid-tree-refresh' can re-run the fetch that produced this tree."
   "Re-run the query that produced this tree buffer and re-render it."
   (interactive)
   (funcall (or sayid-tree--refresh-fn #'sayid-tree-view-workspace)))
+
+(defun sayid-tree--stale-query-hint ()
+  "Build the hint shown when a refreshed query no longer matches anything."
+  (format "This query no longer matches anything - the recording changed.
+
+Press `w' for the full workspace, or trace and run something new
+\(`%s' traces the function at point).
+"
+          (sayid--key-hint #'sayid-trace-fn)))
+
+(defun sayid-tree--show-query (fetch-fn title empty-error &optional refreshing)
+  "Fetch roots with FETCH-FN and render them as a tree titled TITLE.
+When nothing matches, signal EMPTY-ERROR - unless REFRESHING is non-nil
+\(a `sayid-tree-refresh' re-run of an existing view), where an emptied
+query renders as an empty tree with a hint, rather than erroring while
+the stale content stays on screen."
+  (let ((roots (funcall fetch-fn))
+        (refresh (lambda ()
+                   (sayid-tree--show-query fetch-fn title empty-error t))))
+    (cond
+     (roots (sayid-tree--render roots title nil refresh))
+     (refreshing
+      (sayid-tree--render nil title (sayid-tree--stale-query-hint) refresh))
+     (t (user-error "%s" empty-error)))))
 
 (defun sayid-tree--query-title (kind selector mod)
   "Build a tree title for a query of KIND on SELECTOR with modifier MOD."
@@ -737,7 +764,11 @@ prompt for which value."
     (sayid-req-insert-content (list "op" "sayid-pprint-value"
                                     "trace-id" (nrepl-dict-get call "id")
                                     "path" path))
-    (goto-char 1)
+    ;; Point may have landed back in the tree buffer; reset the pprint
+    ;; buffer's position without disturbing the tree's.
+    (when-let* ((buf (get-buffer (car sayid-pprint-buf-spec))))
+      (with-current-buffer buf
+        (goto-char (point-min))))
     (sayid-select-default-buf)))
 
 (defun sayid-tree-gen-instance-expr ()
@@ -756,14 +787,12 @@ it into the REPL replays the call."
 
 (defun sayid-tree--show-fn-query (fn-name mod)
   "Fetch and render every recorded call of FN-NAME, with query modifier MOD."
-  (let ((roots (sayid-req-get-value (list "op" "sayid-query-by-fn-data"
-                                          "fn-name" fn-name
-                                          "mod" mod))))
-    (if roots
-        (sayid-tree--render roots (sayid-tree--query-title "fn" fn-name mod)
-                            nil
-                            (lambda () (sayid-tree--show-fn-query fn-name mod)))
-      (user-error "No recorded calls of %s" fn-name))))
+  (sayid-tree--show-query
+   (lambda () (sayid-req-get-value (list "op" "sayid-query-by-fn-data"
+                                         "fn-name" fn-name
+                                         "mod" mod)))
+   (sayid-tree--query-title "fn" fn-name mod)
+   (format "No recorded calls of %s" fn-name)))
 
 (defun sayid-tree-query-fn (&optional arg)
   "Re-render the tree with every recorded call of the function at point.
@@ -774,14 +803,12 @@ With a prefix ARG, also prompt for a query modifier."
 
 (defun sayid-tree--show-id-query (id mod)
   "Fetch and render the recorded call ID and its subtree, with modifier MOD."
-  (let ((roots (sayid-req-get-value (list "op" "sayid-query-by-id-data"
-                                          "trace-id" id
-                                          "mod" mod))))
-    (if roots
-        (sayid-tree--render roots (sayid-tree--query-title "id" id mod)
-                            nil
-                            (lambda () (sayid-tree--show-id-query id mod)))
-      (user-error "Call %s not found" id))))
+  (sayid-tree--show-query
+   (lambda () (sayid-req-get-value (list "op" "sayid-query-by-id-data"
+                                         "trace-id" id
+                                         "mod" mod)))
+   (sayid-tree--query-title "id" id mod)
+   (format "Call %s not found" id)))
 
 (defun sayid-tree-query-id (&optional arg)
   "Re-render the tree focused on the call at point.
@@ -799,7 +826,8 @@ When nothing has been recorded yet the buffer explains how to get going.
 See `sayid-tree-mode' for the keys available in the tree buffer."
   (interactive)
   (let ((roots (sayid-req-get-value (list "op" "sayid-get-workspace-data"))))
-    (sayid-tree--render roots "Sayid workspace" sayid-tree--empty-workspace-hint
+    (sayid-tree--render roots "Sayid workspace"
+                        (sayid-tree--empty-workspace-hint)
                         #'sayid-tree-view-workspace)))
 
 (defvar sayid-tree-mode-map
@@ -908,15 +936,19 @@ management: \\<sayid-traced-tree-mode-map>\\[sayid-traced-enable] enable,
 \\[sayid-traced-inner-trace] inner-trace, \\[sayid-traced-outer-trace]
 outer-trace the entry at point, \\[sayid-traced-refresh] refresh the view.")
 
-(defconst sayid-traced--empty-hint
-  "Nothing is traced yet.
+(defun sayid-traced--empty-hint ()
+  "Build the hint shown in the traced-functions buffer when nothing is traced.
+The key sequences are looked up live, so a custom prefix shows correctly."
+  (format "Nothing is traced yet.
 
-In a Clojure buffer, `sayid-trace-ns-in-file' (`C-c s t b') traces the
-buffer's namespace; `sayid-trace-ns-by-pattern' (`C-c s t p') traces
+In a Clojure buffer, `sayid-trace-ns-in-file' (`%s') traces the
+buffer's namespace; `sayid-trace-ns-by-pattern' (`%s') traces
 namespaces by a wildcard pattern.  Then run some code and view the
-recording with `sayid-tree-view-workspace' (`C-c s w').
+recording with `sayid-tree-view-workspace' (`%s').
 "
-  "What to show in the traced-functions buffer when nothing is traced.")
+          (sayid--key-hint #'sayid-trace-ns-in-file)
+          (sayid--key-hint #'sayid-trace-ns-by-pattern)
+          (sayid--key-hint #'sayid-tree-view-workspace)))
 
 (defvar-local sayid-traced--ns nil
   "The namespace filter this traced-functions buffer was rendered with.")
@@ -933,7 +965,7 @@ GROUPS is empty, show a hint on how to trace something instead."
                             "Traced functions"
                             (unless groups
                               (lambda ()
-                                (insert (propertize sayid-traced--empty-hint
+                                (insert (propertize (sayid-traced--empty-hint)
                                                     'face 'shadow)))))))
 
 (defun sayid-traced-refresh ()

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -367,7 +367,7 @@ Refreshes the traced-functions view when it is visible."
                    (sayid--key-hint #'sayid-tree-view-workspace)))))
      ((not was-traced)
       (user-error "%s isn't traced - trace it first with `%s'"
-                  sym (sayid--key-hint #'sayid-outer-trace-fn)))
+                  sym (sayid--key-hint #'sayid-trace-fn)))
      (t
       (message "%s the trace on %s"
                (pcase action
@@ -390,22 +390,39 @@ Refreshes the traced-functions view when it is visible."
   (sayid--trace-fn-at-point "disable"))
 
 ;;;###autoload
-(defun sayid-outer-trace-fn ()
+(defun sayid-trace-fn ()
+  "Trace the function at point.
+This is the place to start: it records every call of the function -
+arguments and return value - into the workspace.  Same as
+`sayid-trace-fn-outer'; use `sayid-trace-fn-inner' to also record the
+expressions evaluated inside the function."
+  (interactive)
+  (sayid--trace-fn-at-point "add-outer"))
+
+;;;###autoload
+(defun sayid-trace-fn-outer ()
   "Trace the function at point, recording its arguments and return value."
   (interactive)
   (sayid--trace-fn-at-point "add-outer"))
 
 ;;;###autoload
-(defun sayid-inner-trace-fn ()
+(defun sayid-trace-fn-inner ()
   "Inner-trace the function at point, also recording its inner expressions."
   (interactive)
   (sayid--trace-fn-at-point "add-inner"))
 
 ;;;###autoload
-(defun sayid-remove-trace-fn ()
+(defun sayid-trace-fn-remove ()
   "Remove the trace of the function at point."
   (interactive)
   (sayid--trace-fn-at-point "remove"))
+
+(define-obsolete-function-alias 'sayid-outer-trace-fn
+  #'sayid-trace-fn-outer "0.8.0")
+(define-obsolete-function-alias 'sayid-inner-trace-fn
+  #'sayid-trace-fn-inner "0.8.0")
+(define-obsolete-function-alias 'sayid-remove-trace-fn
+  #'sayid-trace-fn-remove "0.8.0")
 
 ;;;###autoload
 (defun sayid-load-enable-clear ()
@@ -608,8 +625,9 @@ the thrown error, or a named argument."
 
 To record something:
 
-  1. Trace what you're interested in: `sayid-trace-ns-in-file'
-     (`C-c s t b') traces the current buffer's namespace.
+  1. Trace what you're interested in: `sayid-trace-fn' (`C-c s t t')
+     traces the function at point, `sayid-trace-ns-in-file'
+     (`C-c s t b') the current buffer's whole namespace.
   2. Run some code that calls what you traced (eval a form,
      run a test, hit an endpoint).
   3. Refresh this buffer with `g' (or `C-c s w' from anywhere).
@@ -1138,6 +1156,7 @@ file can be found, jump to it."
     (define-key map (kbd "f")   'sayid-query-form-at-point)
     (define-key map (kbd "!")   'sayid-load-enable-clear)
     (define-key map (kbd "w")   'sayid-tree-view-workspace)
+    (define-key map (kbd "t t") 'sayid-trace-fn)
     (define-key map (kbd "t y") 'sayid-trace-all-ns-in-dir)
     (define-key map (kbd "t p") 'sayid-trace-ns-by-pattern)
     (define-key map (kbd "t b") 'sayid-trace-ns-in-file)
@@ -1145,9 +1164,9 @@ file can be found, jump to it."
     (define-key map (kbd "t E") 'sayid-trace-enable-all)
     (define-key map (kbd "t d") 'sayid-trace-fn-disable)
     (define-key map (kbd "t D") 'sayid-trace-disable-all)
-    (define-key map (kbd "t n") 'sayid-inner-trace-fn)
-    (define-key map (kbd "t o") 'sayid-outer-trace-fn)
-    (define-key map (kbd "t r") 'sayid-remove-trace-fn)
+    (define-key map (kbd "t n") 'sayid-trace-fn-inner)
+    (define-key map (kbd "t o") 'sayid-trace-fn-outer)
+    (define-key map (kbd "t r") 'sayid-trace-fn-remove)
     (define-key map (kbd "t K") 'sayid-kill-all-traces)
     (define-key map (kbd "d t") 'sayid-tap-trace)
     (define-key map (kbd "d b") 'sayid-capture-baseline)

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -329,9 +329,15 @@ state.  POS is the position to move cursor to."
 
 ;;;###autoload
 (defun sayid-query-form-at-point ()
-  "Show every recorded call of the form at point as a tree."
+  "Show every recorded call of the form at point as a tree.
+Falls back to the legacy text view when the connected middleware predates
+the `sayid-query-form-at-point-data' op."
   (interactive)
-  (sayid-tree--show-form-query (buffer-file-name) (line-number-at-pos)))
+  (if (cider-nrepl-op-supported-p "sayid-query-form-at-point-data")
+      (sayid-tree--show-form-query (buffer-file-name) (line-number-at-pos))
+    (sayid-req-insert-content (list "op" "sayid-query-form-at-point"
+                                    "file" (buffer-file-name)
+                                    "line" (line-number-at-pos)))))
 
 ;;;###autoload
 (defun sayid-get-meta-at-point ()
@@ -363,26 +369,34 @@ to naming the command."
 
 (defun sayid--trace-fn-at-point (action)
   "Apply trace ACTION to the function at point and describe the outcome.
-Refreshes the traced-functions view when it is visible."
-  (let* ((resp (sayid-req-get-value (list "op" "sayid-trace-fn-at-point"
-                                          "action" action
-                                          "file" (buffer-file-name)
-                                          "line" (line-number-at-pos)
-                                          "column" (+ (current-column) 1)
-                                          "source" (buffer-string))))
-         (sym (and resp (nrepl-dict-get resp "sym")))
-         (was-traced (and resp (eql 1 (nrepl-dict-get resp "was-traced")))))
+Refreshes the traced-functions view when it is visible.  Works against an
+older middleware too - its reply just carries the symbol without the
+`was-traced' slot, so the outcome is described less precisely."
+  (let* ((resp (sayid--send-sync-request (list "op" "sayid-trace-fn-at-point"
+                                               "action" action
+                                               "file" (buffer-file-name)
+                                               "line" (line-number-at-pos)
+                                               "column" (+ (current-column) 1)
+                                               "source" (buffer-string))))
+         (sym (or (nrepl-dict-get resp "sym")
+                  ;; Pre-0.8 middleware: the symbol is the value itself.
+                  (let ((value (nrepl-dict-get resp "value")))
+                    (and (stringp value) (not (string-empty-p value)) value))))
+         ;; 1, 0, or nil when the middleware is too old to say.
+         (was-traced (nrepl-dict-get resp "was-traced")))
+    (when-let* ((ex (nrepl-dict-get resp "ex")))
+      (user-error "Sayid failed: %s" ex))
     (unless sym
       (user-error "No function at point - put the cursor on a function name"))
     (cond
      ((member action '("add-outer" "add-inner"))
       (let ((kind (if (string= action "add-outer") "outer" "inner")))
-        (if was-traced
+        (if (eql 1 was-traced)
             (message "Switched %s to an %s trace" sym kind)
           (message "%s-traced %s - run some code, then `%s' shows what was recorded"
                    (capitalize kind) sym
                    (sayid--key-hint #'sayid-tree-view-workspace)))))
-     ((not was-traced)
+     ((and (member action '("enable" "disable")) (eql 0 was-traced))
       (user-error "%s isn't traced - trace it first with `%s'"
                   sym (sayid--key-hint #'sayid-trace-fn)))
      (t
@@ -1287,17 +1301,23 @@ menu doubles as the keybinding reference."
     ("h"   "describe all bindings"   sayid-show-help)]])
 
 (defun sayid--menu-key (command)
-  "Return COMMAND's key sequence inside `sayid-menu', or nil."
-  (cl-labels ((scan (x)
+  "Return COMMAND's key sequence inside `sayid-menu', or nil.
+Understands both transient layout encodings: the classic one, where a
+suffix is (LEVEL CLASS PLIST), and the current one, where a suffix is
+\(CLASS . PLIST).  Anything unrecognized just yields nil, which makes
+`sayid--key-hint' fall back to naming the command."
+  (cl-labels ((plist-key (pl)
+                (and (keywordp (car-safe pl))
+                     (eq (plist-get pl :command) command)
+                     (plist-get pl :key)))
+              (scan (x)
                 (cond
                  ((vectorp x) (cl-some #'scan (append x nil)))
                  ((consp x)
-                  (or (and (keywordp (car x))
-                           (plist-member x :command)
-                           (eq (plist-get x :command) command)
-                           (plist-get x :key))
+                  (or (plist-key x)
+                      (and (symbolp (car x)) (plist-key (cdr x)))
                       (cl-some #'scan x))))))
-    (scan (get 'sayid-menu 'transient--layout))))
+    (ignore-errors (scan (get 'sayid-menu 'transient--layout)))))
 
 (defvar sayid-clj-mode-keys
   (let ((map (make-sparse-keymap)))

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -33,8 +33,10 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'cider)
 (require 'cider-tree-view)
+(require 'transient)
 
 (defgroup sayid nil
   "Sayid is an advanced Clojure debugging tool."
@@ -342,13 +344,17 @@ state.  POS is the position to move cursor to."
 
 (defun sayid--key-hint (command)
   "Return a human-readable way to invoke COMMAND.
-Prefers the real keybinding in `clojure-mode-map' (where
-`sayid-setup-package' installs the Sayid keys); falls back to naming
-the command."
-  (let ((key (where-is-internal command (list clojure-mode-map) t)))
-    (if key
-        (key-description key)
-      (format "M-x %s" command))))
+Prefers a direct keybinding in `clojure-mode-map' (where
+`sayid-setup-package' installs the Sayid keys); when the prefix is bound
+to `sayid-menu' instead, spells out the menu key sequence.  Falls back
+to naming the command."
+  (let ((direct (where-is-internal command (list clojure-mode-map) t))
+        (menu (where-is-internal 'sayid-menu (list clojure-mode-map) t)))
+    (cond
+     (direct (key-description direct))
+     ((and menu (sayid--menu-key command))
+      (format "%s %s" (key-description menu) (sayid--menu-key command)))
+     (t (format "M-x %s" command)))))
 
 (defun sayid--refresh-traced-if-visible ()
   "Refresh the traced-functions view when its buffer is visible."
@@ -1211,6 +1217,88 @@ file can be found, jump to it."
   (interactive)
   (sayid--buf-cycle #'sayid-cycle-ring-back))
 
+;;; The Sayid menu
+;;
+;; A transient (magit-style) menu over the same key sequences as the classic
+;; `C-c s' prefix map, so the menu teaches the keys instead of replacing them:
+;; `C-c s t b' does the same thing whether you read it off the menu or type
+;; it blind.
+
+(defun sayid--menu-status ()
+  "Return a line of live workspace state for the menu header, or nil.
+Answers what a newcomer needs to place themselves in the trace -> run ->
+inspect loop: how much is traced, and how much has been recorded."
+  (condition-case nil
+      (format "%s traced (%s enabled) | %s calls recorded"
+              (sayid-req-get-value '("op" "sayid-get-trace-count"))
+              (sayid-req-get-value '("op" "sayid-get-enabled-trace-count"))
+              (sayid-req-get-value '("op" "sayid-get-log-count")))
+    (error nil)))
+
+(defun sayid--menu-description ()
+  "Build the header line for `sayid-menu'.
+Shows live traced/recorded state when connected, and what is missing
+\(a REPL, or the middleware) when not."
+  (concat
+   "Sayid"
+   (propertize
+    (cond
+     ((not (cider-connected-p))
+      "  [no REPL - start one with cider-jack-in]")
+     ((not (cider-nrepl-op-supported-p "sayid-get-log-count" nil 'skip-ensure))
+      "  [Sayid middleware not loaded (or too old) - see the README]")
+     (t (let ((status (sayid--menu-status)))
+          (if status (format "  [%s]" status) ""))))
+    'face 'shadow)))
+
+;;;###autoload (autoload 'sayid-menu "sayid" nil t)
+(transient-define-prefix sayid-menu ()
+  "Sayid's main menu: trace something, run your code, explore the recording.
+Every key here is also a direct key sequence on the same prefix, so the
+menu doubles as the keybinding reference."
+  [:description sayid--menu-description ""]
+  [["Trace"
+    ("t t" "function at point"      sayid-trace-fn)
+    ("t n" "fn at point, inner"     sayid-trace-fn-inner)
+    ("t o" "fn at point, outer"     sayid-trace-fn-outer)
+    ("t b" "buffer's namespace"     sayid-trace-ns-in-file)
+    ("t p" "namespaces by pattern"  sayid-trace-ns-by-pattern)
+    ("t y" "namespaces in a dir"    sayid-trace-all-ns-in-dir)]
+   ["Manage traces"
+    ("s"   "show what's traced"     sayid-show-traced)
+    ("S"   "show traced, this ns"   sayid-show-traced-ns)
+    ("t e" "enable fn trace"        sayid-trace-fn-enable)
+    ("t d" "disable fn trace"       sayid-trace-fn-disable)
+    ("t r" "remove fn trace"        sayid-trace-fn-remove)
+    ("t E" "enable all"             sayid-trace-enable-all)
+    ("t D" "disable all"            sayid-trace-disable-all)
+    ("t K" "remove all"             sayid-kill-all-traces)]]
+  [["Recording"
+    ("w"   "view the workspace tree" sayid-tree-view-workspace)
+    ("f"   "calls of form at point"  sayid-query-form-at-point)
+    ("!"   "reload buffer, clear log" sayid-load-enable-clear)
+    ("c"   "clear the log"           sayid-clear-log)
+    ("x"   "reset the workspace"     sayid-reset-workspace)]
+   ["Data tools"
+    ("d t" "tap the trace"           sayid-tap-trace)
+    ("d b" "capture baseline"        sayid-capture-baseline)
+    ("d d" "diff vs baseline"        sayid-diff-traces)
+    ("V s" "set the view"            sayid-set-view)
+    ("h"   "describe all bindings"   sayid-show-help)]])
+
+(defun sayid--menu-key (command)
+  "Return COMMAND's key sequence inside `sayid-menu', or nil."
+  (cl-labels ((scan (x)
+                (cond
+                 ((vectorp x) (cl-some #'scan (append x nil)))
+                 ((consp x)
+                  (or (and (keywordp (car x))
+                           (plist-member x :command)
+                           (eq (plist-get x :command) command)
+                           (plist-get x :key))
+                      (cl-some #'scan x))))))
+    (scan (get 'sayid-menu 'transient--layout))))
+
 (defvar sayid-clj-mode-keys
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "f")   'sayid-query-form-at-point)
@@ -1314,13 +1402,27 @@ PREFIX is the key prefix to bind the sayid commands under."
   (buffer-disable-undo))
 
 
+(defcustom sayid-use-menu t
+  "When non-nil, `sayid-setup-package' binds the prefix to `sayid-menu'.
+The menu shows the commands grouped by workflow, using the same key
+sequences as the classic prefix map (so e.g. `C-c s t b' works either
+way).  Set to nil to bind the raw `sayid-clj-mode-keys' prefix map
+without the menu popping up."
+  :package-version '(sayid . "0.8.0")
+  :type 'boolean)
+
 ;;;###autoload
 (defun sayid-setup-package (&optional clj-mode-prefix)
   "Set up the sayid package.
 CLJ-MODE-PREFIX sets the prefix key for the `clojure-mode' keybindings.
-When omitted, it defaults to the usual sayid prefix."
+When omitted, it defaults to the usual sayid prefix.  The prefix opens
+`sayid-menu' unless `sayid-use-menu' is nil, in which case the classic
+prefix keymap is bound directly."
   (interactive)
-  (sayid-set-clj-mode-keys (or clj-mode-prefix (kbd "C-c s"))))
+  (let ((prefix (or clj-mode-prefix (kbd "C-c s"))))
+    (if sayid-use-menu
+        (define-key clojure-mode-map prefix #'sayid-menu)
+      (sayid-set-clj-mode-keys prefix))))
 
 (provide 'sayid)
 

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -312,13 +312,24 @@ state.  POS is the position to move cursor to."
   (sayid-setup-buf (sayid-req-get-value req) t nil))
 
 
+(defun sayid-tree--show-form-query (file line)
+  "Fetch and render every recorded call of the form at FILE and LINE as a tree."
+  (let ((roots (sayid-req-get-value (list "op" "sayid-query-form-at-point-data"
+                                          "file" file
+                                          "line" line))))
+    (if roots
+        (sayid-tree--render roots
+                            (format "Query: %s:%s"
+                                    (file-name-nondirectory file) line)
+                            nil
+                            (lambda () (sayid-tree--show-form-query file line)))
+      (user-error "No recorded calls for the form at point"))))
+
 ;;;###autoload
 (defun sayid-query-form-at-point ()
-  "Query sayid for invocations of the function defined at point."
+  "Show every recorded call of the form at point as a tree."
   (interactive)
-  (sayid-req-insert-content (list "op" "sayid-query-form-at-point"
-                                  "file" (buffer-file-name)
-                                  "line" (line-number-at-pos))))
+  (sayid-tree--show-form-query (buffer-file-name) (line-number-at-pos)))
 
 ;;;###autoload
 (defun sayid-get-meta-at-point ()
@@ -660,6 +671,20 @@ so `sayid-tree-refresh' can re-run the fetch that produced this tree."
   (format "Query: %s %s%s" kind selector
           (if (string-empty-p mod) "" (format " [%s]" mod))))
 
+(defun sayid-tree--read-value-path (call prompt-p)
+  "Pick one of CALL's captured values and return its `sayid-def-value' path.
+By default picks the return value (or the thrown error); with PROMPT-P
+non-nil, prompt for which value - the return, the throw, or a named
+argument."
+  (let ((targets (or (sayid-tree--value-targets call)
+                     (user-error "This call has no captured values"))))
+    (if prompt-p
+        (or (cdr (assoc (completing-read "Value: " targets nil t) targets))
+            (user-error "No value selected"))
+      (or (cdr (assoc "return" targets))
+          (cdr (assoc "throw" targets))
+          (user-error "This call has no return value")))))
+
 (defun sayid-tree-inspect (&optional arg)
   "Inspect a captured value of the call at point in CIDER's inspector.
 Defs the value to `$s/*' server-side and hands the live object to
@@ -667,17 +692,47 @@ Defs the value to `$s/*' server-side and hands the live object to
 error); with a prefix ARG, prompt for which value - the return, the throw, or
 a named argument."
   (interactive "P")
+  (let ((call (sayid-tree--call-at-point)))
+    (sayid--inspect-value (nrepl-dict-get call "id")
+                          (sayid-tree--read-value-path call arg))))
+
+(defun sayid-tree-def-value (&optional arg)
+  "Def a captured value of the call at point to the `$s/*' var.
+By default defs the return value (or the thrown error); with a prefix ARG,
+prompt for which value.  Handy for poking at a captured value in the REPL."
+  (interactive "P")
+  (let ((call (sayid-tree--call-at-point)))
+    (sayid-send-and-message (list "op" "sayid-def-value"
+                                  "trace-id" (nrepl-dict-get call "id")
+                                  "path" (sayid-tree--read-value-path call arg)))))
+
+(defun sayid-tree-pprint (&optional arg)
+  "Pretty-print a captured value of the call at point in its own buffer.
+By default prints the return value (or the thrown error); with a prefix ARG,
+prompt for which value."
+  (interactive "P")
   (let* ((call (sayid-tree--call-at-point))
-         (targets (or (sayid-tree--value-targets call)
-                      (user-error "This call has no values to inspect")))
-         (path (if arg
-                   (or (cdr (assoc (completing-read "Inspect value: " targets nil t)
-                                   targets))
-                       (user-error "No value selected"))
-                 (or (cdr (assoc "return" targets))
-                     (cdr (assoc "throw" targets))
-                     (user-error "This call has no return value to inspect")))))
-    (sayid--inspect-value (nrepl-dict-get call "id") path)))
+         (path (sayid-tree--read-value-path call arg)))
+    (sayid-select-pprint-buf)
+    (sayid-req-insert-content (list "op" "sayid-pprint-value"
+                                    "trace-id" (nrepl-dict-get call "id")
+                                    "path" path))
+    (goto-char 1)
+    (sayid-select-default-buf)))
+
+(defun sayid-tree-gen-instance-expr ()
+  "Put an expression reproducing the call at point in the kill ring.
+The expression calls the function with the recorded arguments, so yanking
+it into the REPL replays the call."
+  (interactive)
+  (let* ((call (sayid-tree--call-at-point))
+         (expr (sayid-req-get-value
+                (list "op" "sayid-gen-instance-expr"
+                      "trace-id" (nrepl-dict-get call "id")))))
+    (if (or (null expr) (string= "" expr))
+        (message "Sayid couldn't generate a reproduction expression here")
+      (kill-new expr)
+      (message "Written to kill ring: %s" expr))))
 
 (defun sayid-tree--show-fn-query (fn-name mod)
   "Fetch and render every recorded call of FN-NAME, with query modifier MOD."
@@ -734,6 +789,9 @@ See `sayid-tree-mode' for the keys available in the tree buffer."
     (define-key map (kbd "i")   #'sayid-tree-query-id)
     (define-key map (kbd "w")   #'sayid-tree-view-workspace)
     (define-key map (kbd "c i") #'sayid-tree-inspect)
+    (define-key map (kbd "c d") #'sayid-tree-def-value)
+    (define-key map (kbd "c p") #'sayid-tree-pprint)
+    (define-key map (kbd "c r") #'sayid-tree-gen-instance-expr)
     map)
   "Keymap for `sayid-tree-mode', layered over `cider-tree-view-mode-map'.")
 
@@ -742,8 +800,10 @@ See `sayid-tree-mode' for the keys available in the tree buffer."
 Inherits navigation and folding from `cider-tree-view-mode' and adds Sayid
 actions: \\<sayid-tree-mode-map>\\[sayid-tree-query-fn] query the function at
 point, \\[sayid-tree-query-id] focus the call at point, \\[sayid-tree-inspect]
-inspect a value, \\[sayid-tree-refresh] refresh the current view,
-\\[sayid-tree-view-workspace] back to the full workspace.")
+inspect a value, \\[sayid-tree-def-value] def a value to `$s/*',
+\\[sayid-tree-pprint] pretty-print a value, \\[sayid-tree-gen-instance-expr]
+copy an expression reproducing the call, \\[sayid-tree-refresh] refresh the
+current view, \\[sayid-tree-view-workspace] back to the full workspace.")
 
 (defun sayid-traced--fn-node (fn)
   "Make a `cider-tree-view-node' for a traced-function dict FN.

--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -567,12 +567,29 @@ the thrown error, or a named argument."
                   (user-error "No call at point"))))
     (cider-tree-view-node-value node)))
 
-(defun sayid-tree--render (roots title)
+(defconst sayid-tree--empty-workspace-hint
+  "The workspace is empty - Sayid hasn't recorded any calls yet.
+
+To record something:
+
+  1. Trace what you're interested in: `sayid-trace-ns-in-file'
+     (`C-c s t b') traces the current buffer's namespace.
+  2. Run some code that calls what you traced (eval a form,
+     run a test, hit an endpoint).
+  3. View the recording with `sayid-tree-view-workspace' (`C-c s w').
+"
+  "What to show in the workspace tree buffer when nothing was recorded.")
+
+(defun sayid-tree--render (roots title &optional empty-hint)
   "Render ROOTS, a list of `sayid-get-workspace-data' nodes, as a tree.
-TITLE is shown in the header line."
+TITLE is shown in the header line.  When ROOTS is empty, show EMPTY-HINT
+\(a string) instead of a blank buffer."
   (with-current-buffer (cider-popup-buffer "*sayid-tree*" 'select
                                            'sayid-tree-mode 'ancillary)
-    (cider-tree-view-render (mapcar #'sayid-tree--make-node roots) title)))
+    (cider-tree-view-render (mapcar #'sayid-tree--make-node roots) title
+                            (when (and empty-hint (null roots))
+                              (lambda ()
+                                (insert (propertize empty-hint 'face 'shadow)))))))
 
 (defun sayid-tree--query-title (kind selector mod)
   "Build a tree title for a query of KIND on SELECTOR with modifier MOD."
@@ -629,12 +646,11 @@ With a prefix ARG, also prompt for a query modifier (e.g. \"a\" for ancestors,
 (defun sayid-tree-view-workspace ()
   "Show the recorded workspace as a navigable, foldable tree.
 Built from the `sayid-get-workspace-data' op, rendered with `cider-tree-view'.
+When nothing has been recorded yet the buffer explains how to get going.
 See `sayid-tree-mode' for the keys available in the tree buffer."
   (interactive)
   (let ((roots (sayid-req-get-value (list "op" "sayid-get-workspace-data"))))
-    (if roots
-        (sayid-tree--render roots "Sayid workspace")
-      (user-error "The Sayid workspace is empty, or Sayid isn't loaded"))))
+    (sayid-tree--render roots "Sayid workspace" sayid-tree--empty-workspace-hint)))
 
 (defvar sayid-tree-mode-map
   (let ((map (make-sparse-keymap)))
@@ -734,22 +750,39 @@ management: \\<sayid-traced-tree-mode-map>\\[sayid-traced-enable] enable,
 \\[sayid-traced-inner-trace] inner-trace, \\[sayid-traced-outer-trace]
 outer-trace the entry at point.")
 
+(defconst sayid-traced--empty-hint
+  "Nothing is traced yet.
+
+In a Clojure buffer, `sayid-trace-ns-in-file' (`C-c s t b') traces the
+buffer's namespace; `sayid-trace-ns-by-pattern' (`C-c s t p') traces
+namespaces by a wildcard pattern.  Then run some code and view the
+recording with `sayid-tree-view-workspace' (`C-c s w').
+"
+  "What to show in the traced-functions buffer when nothing is traced.")
+
+(defun sayid-traced--render (groups)
+  "Render GROUPS, a list of `sayid-show-traced-data' namespace groups.
+When GROUPS is empty, show a hint on how to trace something instead."
+  (with-current-buffer (cider-popup-buffer "*sayid-traced*" 'select
+                                           'sayid-traced-tree-mode 'ancillary)
+    (cider-tree-view-render (mapcar #'sayid-traced--ns-node groups)
+                            "Traced functions"
+                            (unless groups
+                              (lambda ()
+                                (insert (propertize sayid-traced--empty-hint
+                                                    'face 'shadow)))))))
+
 ;;;###autoload
 (defun sayid-show-traced (&optional ns)
   "Show what Sayid has traced as a namespaces to functions tree.
-With NS, restrict to that namespace.
+With NS, restrict to that namespace.  When nothing is traced the buffer
+explains how to trace something.
 See `sayid-traced-tree-mode' for the keys (RET jumps to source; e/d/r/i/o
 manage traces)."
   (interactive)
-  (let ((groups (sayid-req-get-value
-                 (append (list "op" "sayid-show-traced-data")
-                         (when ns (list "ns" ns))))))
-    (if groups
-        (with-current-buffer (cider-popup-buffer "*sayid-traced*" 'select
-                                                 'sayid-traced-tree-mode 'ancillary)
-          (cider-tree-view-render (mapcar #'sayid-traced--ns-node groups)
-                                  "Traced functions"))
-      (user-error "Nothing is traced"))))
+  (sayid-traced--render (sayid-req-get-value
+                         (append (list "op" "sayid-show-traced-data")
+                                 (when ns (list "ns" ns))))))
 
 ;;;###autoload
 (defun sayid-show-traced-ns ()

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -301,6 +301,11 @@ reported) when the function isn't traced, instead of silently no-oping."
            count-enabled-traces
            (reply:clj->nrepl msg $)))
 
+(defn ^:nrepl sayid-get-log-count
+  "Reply with the number of top-level calls currently recorded in the workspace."
+  [msg]
+  (reply:clj->nrepl msg (count (:children (sd/ws-deref!)))))
+
 (defn ^:nrepl sayid-trace-fn
   "Apply trace ACTION to the function named by MSG's fn-ns/fn-name."
   [{:keys [action fn-name fn-ns] :as msg}]

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -181,22 +181,28 @@ qualified function symbol."
 
 (defn ^:nrepl sayid-trace-fn-at-point
   "Apply trace ACTION to the function whose symbol sits at the cursor position
-described by MSG (file/line/column/source).  Replies with a map of the resolved
-symbol (`sym`) and whether it was traced before the action (`was-traced`, 0/1),
-so the client can describe the outcome truthfully - or an empty map when no
-function resolves there.  Enable/disable/remove are skipped (but still
-reported) when the function isn't traced, instead of silently no-oping."
-  [{:keys [action file line column source] :as msg}]
+described by MSG (file/line/column/source).  The reply's `:value` stays the
+resolved symbol (or an empty string), exactly as older clients expect; the
+outcome details ride along as extra response slots - `:sym` and `:was-traced`
+(0/1, the state before the action) - so a current client can describe the
+outcome truthfully.  Enable/disable are skipped (but still reported) when the
+function isn't traced; remove always runs, since it also reconciles a var
+whose trace fell out of sync with the workspace's traced sets."
+  [{:keys [action file line column source transport] :as msg}]
   (let [sym (get-sym-at-pos-in-source file line column source)
         ns-sym (symbol (parse-ns-name-from-source source))
         qual-sym (sym/resolve-to-qual-sym ns-sym sym)]
     (if-not qual-sym
-      (reply:data msg {})
+      (do (t/send transport (response-for msg :value ""))
+          (send-status-done msg))
       (let [was-traced (fn-traced? qual-sym)]
-        (when (or was-traced (#{"add-outer" "add-inner"} action))
+        (when (or was-traced (not (#{"enable" "disable"} action)))
           ((fn-trace-actions action) qual-sym))
-        (reply:data msg {"sym"        (str qual-sym)
-                         "was-traced" (if was-traced 1 0)})))))
+        (t/send transport (response-for msg
+                                        :value (str qual-sym)
+                                        :sym (str qual-sym)
+                                        :was-traced (if was-traced 1 0)))
+        (send-status-done msg)))))
 
 ;; ======================
 

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -664,6 +664,12 @@ reported) when the function isn't traced, instead of silently no-oping."
   (reply:data msg (query-tree->data
                    (buf-query-tree [#'parent-name-or-name (symbol fn-name)] mod))))
 
+(defn ^:nrepl sayid-query-form-at-point-data
+  "Data counterpart of `sayid-query-form-at-point`: the recorded calls matching
+  the form at FILE/LINE as node data.  See doc/nrepl-api.md."
+  [{:keys [file line] :as msg}]
+  (reply:data msg (query-tree->data (sd/ws-query-by-file-pos file line))))
+
 (def sayid-nrepl-ops
   (->> *ns*
        ns-interns

--- a/src/sayid/nrepl_middleware.clj
+++ b/src/sayid/nrepl_middleware.clj
@@ -170,17 +170,33 @@ qualified function symbol."
    "disable"   sd/ws-disable-trace-fn!
    "remove"    sd/ws-remove-trace-fn!})
 
+(defn- fn-traced?
+  "True when QUAL-SYM is currently traced - individually or via its namespace."
+  [qual-sym]
+  (let [{ns-syms :ns fn-syms :fn inner-syms :inner-fn}
+        (:traced (sd/ws-get-active!))]
+    (boolean (or (contains? fn-syms qual-sym)
+                 (contains? inner-syms qual-sym)
+                 (contains? ns-syms (symbol (namespace qual-sym)))))))
+
 (defn ^:nrepl sayid-trace-fn-at-point
   "Apply trace ACTION to the function whose symbol sits at the cursor position
-described by MSG (file/line/column/source).  Replies with the resolved symbol,
-or nil when nothing resolves there."
+described by MSG (file/line/column/source).  Replies with a map of the resolved
+symbol (`sym`) and whether it was traced before the action (`was-traced`, 0/1),
+so the client can describe the outcome truthfully - or an empty map when no
+function resolves there.  Enable/disable/remove are skipped (but still
+reported) when the function isn't traced, instead of silently no-oping."
   [{:keys [action file line column source] :as msg}]
   (let [sym (get-sym-at-pos-in-source file line column source)
         ns-sym (symbol (parse-ns-name-from-source source))
         qual-sym (sym/resolve-to-qual-sym ns-sym sym)]
-    (when qual-sym
-      ((fn-trace-actions action) qual-sym))
-    (reply:clj->nrepl msg qual-sym)))
+    (if-not qual-sym
+      (reply:data msg {})
+      (let [was-traced (fn-traced? qual-sym)]
+        (when (or was-traced (#{"add-outer" "add-inner"} action))
+          ((fn-trace-actions action) qual-sym))
+        (reply:data msg {"sym"        (str qual-sym)
+                         "was-traced" (if was-traced 1 0)})))))
 
 ;; ======================
 

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -395,5 +395,63 @@
       (expect (cider-tree-view-node-value (car children)) :to-equal
               (nrepl-dict "name" "foo" "file" "my/ns.clj" "line" 3)))))
 
+(describe "sayid-menu"
+  (it "is a transient prefix"
+    (expect (fboundp 'sayid-menu) :to-be-truthy)
+    (expect (get 'sayid-menu 'transient--layout) :not :to-be nil))
+
+  (it "uses the same key sequences as the classic prefix map"
+    ;; The menu should teach the keys, not invent new ones: every command it
+    ;; lists must sit on the identical key sequence in `sayid-clj-mode-keys'.
+    (dolist (cmd '(sayid-trace-fn sayid-trace-fn-inner sayid-trace-fn-outer
+                                  sayid-trace-ns-in-file sayid-trace-ns-by-pattern
+                                  sayid-trace-all-ns-in-dir sayid-show-traced
+                                  sayid-show-traced-ns sayid-trace-fn-enable
+                                  sayid-trace-fn-disable sayid-trace-fn-remove
+                                  sayid-trace-enable-all sayid-trace-disable-all
+                                  sayid-kill-all-traces sayid-tree-view-workspace
+                                  sayid-query-form-at-point sayid-load-enable-clear
+                                  sayid-clear-log sayid-reset-workspace
+                                  sayid-tap-trace sayid-capture-baseline
+                                  sayid-diff-traces sayid-set-view sayid-show-help))
+      (expect (sayid--menu-key cmd) :to-equal
+              (key-description
+               (where-is-internal cmd (list sayid-clj-mode-keys) t)))))
+
+  (it "reports the missing REPL in the header"
+    (spy-on 'cider-connected-p :and-return-value nil)
+    (expect (sayid--menu-description) :to-match "no REPL"))
+
+  (it "reports a missing middleware in the header"
+    (spy-on 'cider-connected-p :and-return-value t)
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (expect (sayid--menu-description) :to-match "middleware not loaded"))
+
+  (it "shows live traced/recorded state when connected"
+    (spy-on 'cider-connected-p :and-return-value t)
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+    (spy-on 'sayid-req-get-value :and-call-fake
+            (lambda (req)
+              (pcase (cadr req)
+                ("sayid-get-trace-count" 3)
+                ("sayid-get-enabled-trace-count" 2)
+                ("sayid-get-log-count" 12))))
+    (expect (sayid--menu-description)
+            :to-match "3 traced (2 enabled) | 12 calls recorded")))
+
+(describe "sayid-setup-package"
+  (it "binds the prefix to the menu by default"
+    (let ((clojure-mode-map (make-sparse-keymap))
+          (sayid-use-menu t))
+      (sayid-setup-package)
+      (expect (lookup-key clojure-mode-map (kbd "C-c s")) :to-be 'sayid-menu)))
+
+  (it "binds the classic prefix map when the menu is disabled"
+    (let ((clojure-mode-map (make-sparse-keymap))
+          (sayid-use-menu nil))
+      (sayid-setup-package)
+      (expect (lookup-key clojure-mode-map (kbd "C-c s w"))
+              :to-be 'sayid-tree-view-workspace))))
+
 (provide 'sayid-test)
 ;;; sayid-test.el ends here

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -281,7 +281,37 @@
     (expect (spy-calls-count 'sayid-req-get-value) :to-equal 2)
     (expect (car (spy-calls-args-for 'sayid-req-get-value 1))
             :to-equal '("op" "sayid-query-by-fn-data" "fn-name" "my.ns/foo" "mod" ""))
-    (kill-buffer "*sayid-tree*")))
+    (kill-buffer "*sayid-tree*"))
+
+  (it "renders an emptied query as an empty view instead of erroring"
+    (spy-on 'cider-popup-buffer :and-call-fake
+            (lambda (name _select mode _ancillary)
+              (with-current-buffer (get-buffer-create name)
+                (funcall mode)
+                (current-buffer))))
+    (let ((first-call t))
+      (spy-on 'sayid-req-get-value :and-call-fake
+              (lambda (_req)
+                (prog1 (when first-call
+                         (list (nrepl-dict "id" "1" "name" "my.ns/foo"
+                                           "return" "1")))
+                  (setq first-call nil)))))
+    (sayid-tree--show-fn-query "my.ns/foo" "")
+    (with-current-buffer "*sayid-tree*"
+      (sayid-tree-refresh)
+      (expect (buffer-string) :to-match "no longer matches"))
+    (kill-buffer "*sayid-tree*"))
+
+  (it "keeps the namespace filter when refreshing the visible traced view"
+    (let ((buf (get-buffer-create "*traced-test*")))
+      (with-current-buffer buf
+        (setq-local sayid-traced--ns "my.ns"))
+      (spy-on 'get-buffer-window :and-return-value (selected-window))
+      (spy-on 'window-buffer :and-return-value buf)
+      (spy-on 'sayid-show-traced)
+      (sayid--refresh-traced-if-visible)
+      (expect 'sayid-show-traced :to-have-been-called-with "my.ns")
+      (kill-buffer buf))))
 
 (describe "sayid-tree-inspect"
   (before-each

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -149,6 +149,42 @@
       (expect (cdr (assoc "throw" targets)) :to-equal '("throw"))
       (expect (cdr (assoc "arg x" targets)) :to-equal '("arg-map" "x")))))
 
+(describe "the empty states"
+  (before-each
+    ;; Stand in for `cider-popup-buffer': a fresh buffer in the right mode,
+    ;; without needing window management in batch mode.
+    (spy-on 'cider-popup-buffer :and-call-fake
+            (lambda (name _select mode _ancillary)
+              (with-current-buffer (get-buffer-create name)
+                (funcall mode)
+                (current-buffer)))))
+  (after-each
+    (dolist (name '("*sayid-tree*" "*sayid-traced*"))
+      (when (get-buffer name)
+        (kill-buffer name))))
+
+  (it "renders the workspace tree with a getting-started hint instead of erroring"
+    (spy-on 'sayid-req-get-value :and-return-value nil)
+    (sayid-tree-view-workspace)
+    (with-current-buffer "*sayid-tree*"
+      (expect (buffer-string) :to-match "workspace is empty")
+      (expect (buffer-string) :to-match "sayid-trace-ns-in-file")))
+
+  (it "renders the traced view with a how-to-trace hint instead of erroring"
+    (spy-on 'sayid-req-get-value :and-return-value nil)
+    (sayid-show-traced)
+    (with-current-buffer "*sayid-traced*"
+      (expect (buffer-string) :to-match "Nothing is traced yet")
+      (expect (buffer-string) :to-match "sayid-trace-ns-in-file")))
+
+  (it "shows no hint when the workspace has recorded calls"
+    (spy-on 'sayid-req-get-value :and-return-value
+            (list (nrepl-dict "id" "1" "name" "my.ns/foo" "return" "42")))
+    (sayid-tree-view-workspace)
+    (with-current-buffer "*sayid-tree*"
+      (expect (buffer-string) :not :to-match "workspace is empty")
+      (expect (buffer-string) :to-match "my.ns/foo"))))
+
 (describe "sayid-tree-inspect"
   (before-each
     (spy-on 'sayid-send-and-message)

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -185,6 +185,73 @@
       (expect (buffer-string) :not :to-match "workspace is empty")
       (expect (buffer-string) :to-match "my.ns/foo"))))
 
+(describe "sayid--trace-fn-at-point"
+  (before-each
+    (spy-on 'message)
+    (spy-on 'sayid--refresh-traced-if-visible))
+
+  (it "describes a fresh outer trace and points at the workspace view"
+    (spy-on 'sayid-req-get-value :and-return-value
+            (nrepl-dict "sym" "my.ns/foo" "was-traced" 0))
+    (sayid-outer-trace-fn)
+    (expect (apply #'format (spy-calls-args-for 'message 0))
+            :to-match "Outer-traced my\\.ns/foo")
+    (expect 'sayid--refresh-traced-if-visible :to-have-been-called))
+
+  (it "reports switching the trace kind when the fn was already traced"
+    (spy-on 'sayid-req-get-value :and-return-value
+            (nrepl-dict "sym" "my.ns/foo" "was-traced" 1))
+    (sayid-inner-trace-fn)
+    (expect (apply #'format (spy-calls-args-for 'message 0))
+            :to-match "Switched my\\.ns/foo to an inner trace"))
+
+  (it "refuses to enable a trace that doesn't exist, naming the remedy"
+    (spy-on 'sayid-req-get-value :and-return-value
+            (nrepl-dict "sym" "my.ns/foo" "was-traced" 0))
+    (expect (sayid-trace-fn-enable) :to-throw 'user-error)
+    (expect 'message :not :to-have-been-called))
+
+  (it "errors when point isn't on a function"
+    (spy-on 'sayid-req-get-value :and-return-value (nrepl-dict))
+    (expect (sayid-outer-trace-fn) :to-throw 'user-error)))
+
+(describe "sayid-reset-workspace"
+  (it "does nothing when the user declines the confirmation"
+    (spy-on 'y-or-n-p :and-return-value nil)
+    (spy-on 'sayid--send-sync-request)
+    (sayid-reset-workspace)
+    (expect 'sayid--send-sync-request :not :to-have-been-called))
+
+  (it "resets after the user confirms"
+    (spy-on 'y-or-n-p :and-return-value t)
+    (spy-on 'sayid--send-sync-request)
+    (sayid-reset-workspace)
+    (expect 'sayid--send-sync-request :to-have-been-called-with
+            '("op" "sayid-reset-workspace"))))
+
+(describe "the refresh bindings"
+  (it "bind g in both tree buffers"
+    (expect (lookup-key sayid-tree-mode-map (kbd "g"))
+            :to-be 'sayid-tree-refresh)
+    (expect (lookup-key sayid-traced-tree-mode-map (kbd "g"))
+            :to-be 'sayid-traced-refresh))
+
+  (it "re-runs the fetch that produced the tree buffer"
+    (spy-on 'cider-popup-buffer :and-call-fake
+            (lambda (name _select mode _ancillary)
+              (with-current-buffer (get-buffer-create name)
+                (funcall mode)
+                (current-buffer))))
+    (spy-on 'sayid-req-get-value :and-return-value
+            (list (nrepl-dict "id" "1" "name" "my.ns/foo" "return" "1")))
+    (sayid-tree--show-fn-query "my.ns/foo" "")
+    (with-current-buffer "*sayid-tree*"
+      (sayid-tree-refresh))
+    (expect (spy-calls-count 'sayid-req-get-value) :to-equal 2)
+    (expect (car (spy-calls-args-for 'sayid-req-get-value 1))
+            :to-equal '("op" "sayid-query-by-fn-data" "fn-name" "my.ns/foo" "mod" ""))
+    (kill-buffer "*sayid-tree*")))
+
 (describe "sayid-tree-inspect"
   (before-each
     (spy-on 'sayid-send-and-message)

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -298,6 +298,57 @@
     (expect 'sayid-send-and-message :not :to-have-been-called)
     (expect 'cider-inspect-expr :not :to-have-been-called)))
 
+(describe "the tree value commands"
+  (before-each
+    (spy-on 'sayid-tree--call-at-point :and-return-value
+            (nrepl-dict "id" "7" "return" "42")))
+
+  (it "def a captured value to $s/*"
+    (spy-on 'sayid-send-and-message)
+    (sayid-tree-def-value)
+    (expect 'sayid-send-and-message :to-have-been-called-with
+            '("op" "sayid-def-value" "trace-id" "7" "path" ("return"))))
+
+  (it "pretty-print a captured value"
+    (spy-on 'sayid-req-insert-content)
+    (spy-on 'sayid-select-pprint-buf)
+    (spy-on 'sayid-select-default-buf)
+    (sayid-tree-pprint)
+    (expect 'sayid-req-insert-content :to-have-been-called-with
+            '("op" "sayid-pprint-value" "trace-id" "7" "path" ("return"))))
+
+  (it "put a reproduction expression in the kill ring"
+    (spy-on 'sayid-req-get-value :and-return-value "(my.ns/foo 42)")
+    (spy-on 'message)
+    (sayid-tree-gen-instance-expr)
+    (expect (current-kill 0) :to-equal "(my.ns/foo 42)"))
+
+  (it "report when no reproduction expression could be generated"
+    (spy-on 'sayid-req-get-value :and-return-value "")
+    (spy-on 'kill-new)
+    (spy-on 'message)
+    (sayid-tree-gen-instance-expr)
+    (expect 'kill-new :not :to-have-been-called)))
+
+(describe "sayid-query-form-at-point"
+  (it "renders the matching calls in the tree view"
+    (spy-on 'cider-popup-buffer :and-call-fake
+            (lambda (name _select mode _ancillary)
+              (with-current-buffer (get-buffer-create name)
+                (funcall mode)
+                (current-buffer))))
+    (spy-on 'sayid-req-get-value :and-return-value
+            (list (nrepl-dict "id" "1" "name" "my.ns/foo" "return" "1")))
+    (sayid-tree--show-form-query "/tmp/a.clj" 3)
+    (with-current-buffer "*sayid-tree*"
+      (expect (buffer-string) :to-match "my.ns/foo"))
+    (kill-buffer "*sayid-tree*"))
+
+  (it "errors when nothing was recorded for the form"
+    (spy-on 'sayid-req-get-value :and-return-value nil)
+    (expect (sayid-tree--show-form-query "/tmp/a.clj" 3)
+            :to-throw 'user-error)))
+
 (describe "sayid-buf-inspect-at-point"
   (before-each
     (spy-on 'sayid-send-and-message)

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -191,7 +191,7 @@
     (spy-on 'sayid--refresh-traced-if-visible))
 
   (it "describes a fresh outer trace and points at the workspace view"
-    (spy-on 'sayid-req-get-value :and-return-value
+    (spy-on 'sayid--send-sync-request :and-return-value
             (nrepl-dict "sym" "my.ns/foo" "was-traced" 0))
     (sayid-trace-fn)
     (expect (apply #'format (spy-calls-args-for 'message 0))
@@ -199,21 +199,42 @@
     (expect 'sayid--refresh-traced-if-visible :to-have-been-called))
 
   (it "reports switching the trace kind when the fn was already traced"
-    (spy-on 'sayid-req-get-value :and-return-value
+    (spy-on 'sayid--send-sync-request :and-return-value
             (nrepl-dict "sym" "my.ns/foo" "was-traced" 1))
     (sayid-trace-fn-inner)
     (expect (apply #'format (spy-calls-args-for 'message 0))
             :to-match "Switched my\\.ns/foo to an inner trace"))
 
   (it "refuses to enable a trace that doesn't exist, naming the remedy"
-    (spy-on 'sayid-req-get-value :and-return-value
+    (spy-on 'sayid--send-sync-request :and-return-value
             (nrepl-dict "sym" "my.ns/foo" "was-traced" 0))
     (expect (sayid-trace-fn-enable) :to-throw 'user-error)
     (expect 'message :not :to-have-been-called))
 
+  (it "reports a removed trace even when the workspace didn't list it"
+    (spy-on 'sayid--send-sync-request :and-return-value
+            (nrepl-dict "sym" "my.ns/foo" "was-traced" 0))
+    (sayid-trace-fn-remove)
+    (expect (apply #'format (spy-calls-args-for 'message 0))
+            :to-match "Removed the trace on my\\.ns/foo"))
+
   (it "errors when point isn't on a function"
-    (spy-on 'sayid-req-get-value :and-return-value (nrepl-dict))
+    (spy-on 'sayid--send-sync-request :and-return-value
+            (nrepl-dict "value" ""))
     (expect (sayid-trace-fn) :to-throw 'user-error))
+
+  (it "still works against a pre-0.8 middleware's string reply"
+    (spy-on 'sayid--send-sync-request :and-return-value
+            (nrepl-dict "value" "my.ns/foo"))
+    (sayid-trace-fn-enable)
+    (expect (apply #'format (spy-calls-args-for 'message 0))
+            :to-match "Enabled the trace on my\\.ns/foo"))
+
+  (it "surfaces a middleware error instead of blaming the cursor"
+    (spy-on 'sayid--send-sync-request :and-return-value
+            (nrepl-dict "ex" "clojure.lang.ExceptionInfo"))
+    (expect (sayid-trace-fn)
+            :to-throw 'user-error '("Sayid failed: clojure.lang.ExceptionInfo")))
 
   (it "keeps the old command names alive as obsolete aliases"
     (dolist (old '(sayid-outer-trace-fn sayid-inner-trace-fn
@@ -347,7 +368,17 @@
   (it "errors when nothing was recorded for the form"
     (spy-on 'sayid-req-get-value :and-return-value nil)
     (expect (sayid-tree--show-form-query "/tmp/a.clj" 3)
-            :to-throw 'user-error)))
+            :to-throw 'user-error))
+
+  (it "falls back to the legacy view when the middleware lacks the data op"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (spy-on 'buffer-file-name :and-return-value "/tmp/a.clj")
+    (spy-on 'sayid-req-insert-content)
+    (sayid-query-form-at-point)
+    (expect (car (spy-calls-args-for 'sayid-req-insert-content 0))
+            :to-equal (list "op" "sayid-query-form-at-point"
+                            "file" "/tmp/a.clj"
+                            "line" (line-number-at-pos)))))
 
 (describe "sayid-buf-inspect-at-point"
   (before-each

--- a/test/el/sayid-test.el
+++ b/test/el/sayid-test.el
@@ -193,7 +193,7 @@
   (it "describes a fresh outer trace and points at the workspace view"
     (spy-on 'sayid-req-get-value :and-return-value
             (nrepl-dict "sym" "my.ns/foo" "was-traced" 0))
-    (sayid-outer-trace-fn)
+    (sayid-trace-fn)
     (expect (apply #'format (spy-calls-args-for 'message 0))
             :to-match "Outer-traced my\\.ns/foo")
     (expect 'sayid--refresh-traced-if-visible :to-have-been-called))
@@ -201,7 +201,7 @@
   (it "reports switching the trace kind when the fn was already traced"
     (spy-on 'sayid-req-get-value :and-return-value
             (nrepl-dict "sym" "my.ns/foo" "was-traced" 1))
-    (sayid-inner-trace-fn)
+    (sayid-trace-fn-inner)
     (expect (apply #'format (spy-calls-args-for 'message 0))
             :to-match "Switched my\\.ns/foo to an inner trace"))
 
@@ -213,7 +213,17 @@
 
   (it "errors when point isn't on a function"
     (spy-on 'sayid-req-get-value :and-return-value (nrepl-dict))
-    (expect (sayid-outer-trace-fn) :to-throw 'user-error)))
+    (expect (sayid-trace-fn) :to-throw 'user-error))
+
+  (it "keeps the old command names alive as obsolete aliases"
+    (dolist (old '(sayid-outer-trace-fn sayid-inner-trace-fn
+                                        sayid-remove-trace-fn))
+      (expect (fboundp old) :to-be-truthy)
+      (expect (get old 'byte-obsolete-info) :to-be-truthy)))
+
+  (it "binds the DWIM trace command under t t"
+    (expect (lookup-key sayid-clj-mode-keys (kbd "t t"))
+            :to-be 'sayid-trace-fn)))
 
 (describe "sayid-reset-workspace"
   (it "does nothing when the user declines the confirmation"

--- a/test/sayid/nrepl_middleware_test.clj
+++ b/test/sayid/nrepl_middleware_test.clj
@@ -253,6 +253,48 @@
       (t/is (seq value))
       (t/is (str/includes? (get (first value) "name") "func1")))))
 
+;;; --- Trace-at-point outcomes -------------------------------------------------
+
+(def ^:private point-source
+  "A tiny stand-in for a buffer's source: `func1' sits on line 2."
+  "(ns sayid.test-ns1)\n(defn func1 [arg1] arg1)\n")
+
+(defn- trace-at-point
+  "Drive sayid-trace-fn-at-point with ACTION on `func1' in `point-source'."
+  [action]
+  (captured-value "sayid-trace-fn-at-point"
+                  {:action action :file "fake.clj" :line 2 :column 8
+                   :source point-source}))
+
+(t/deftest trace-fn-at-point-reports-a-fresh-trace
+  (let [value (trace-at-point "add-outer")]
+    (t/is (= "sayid.test-ns1/func1" (get value "sym")))
+    (t/is (= 0 (get value "was-traced")))
+    (t/is (contains? (:fn (:traced (sd/ws-get-active!)))
+                     'sayid.test-ns1/func1)
+          "the outer trace was applied")))
+
+(t/deftest trace-fn-at-point-reports-an-existing-trace
+  (trace-at-point "add-outer")
+  (let [value (trace-at-point "add-inner")]
+    (t/is (= 1 (get value "was-traced")))
+    (t/is (contains? (:inner-fn (:traced (sd/ws-get-active!)))
+                     'sayid.test-ns1/func1)
+          "the trace was switched to inner")))
+
+(t/deftest trace-fn-at-point-skips-managing-an-absent-trace
+  (let [value (trace-at-point "enable")]
+    (t/is (= 0 (get value "was-traced")))
+    (t/is (empty? (:fn (:traced (sd/ws-get-active!))))
+          "enable on an untraced fn applies nothing")))
+
+(t/deftest trace-fn-at-point-reports-nothing-at-point
+  (let [value (captured-value "sayid-trace-fn-at-point"
+                              {:action "add-outer" :file "fake.clj"
+                               :line 2 :column 2
+                               :source "(ns sayid.test-ns1)\n(nonexistent-fn-xyz 1)\n"})]
+    (t/is (empty? value) "no resolvable function replies with an empty map")))
+
 (t/deftest show-traced-renders-the-audit
   (t/testing "sayid-show-traced returns a rendered [text properties] pair"
     (sd/ws-add-trace-ns! ns1)

--- a/test/sayid/nrepl_middleware_test.clj
+++ b/test/sayid/nrepl_middleware_test.clj
@@ -271,6 +271,15 @@
 
 ;;; --- Trace-at-point outcomes -------------------------------------------------
 
+(defn- captured-response
+  "Drive OP through `wrap-sayid` with MSG and return all sent responses,
+  merged into one map."
+  [op msg]
+  (let [sent (atom [])
+        handler (mw/wrap-sayid (fn [_] :unhandled))]
+    (handler (assoc msg :op op :transport (recording-transport sent)))
+    (apply merge @sent)))
+
 (def ^:private point-source
   "A tiny stand-in for a buffer's source: `func1' sits on line 2."
   "(ns sayid.test-ns1)\n(defn func1 [arg1] arg1)\n")
@@ -278,38 +287,49 @@
 (defn- trace-at-point
   "Drive sayid-trace-fn-at-point with ACTION on `func1' in `point-source'."
   [action]
-  (captured-value "sayid-trace-fn-at-point"
-                  {:action action :file "fake.clj" :line 2 :column 8
-                   :source point-source}))
+  (captured-response "sayid-trace-fn-at-point"
+                     {:action action :file "fake.clj" :line 2 :column 8
+                      :source point-source}))
 
 (t/deftest trace-fn-at-point-reports-a-fresh-trace
-  (let [value (trace-at-point "add-outer")]
-    (t/is (= "sayid.test-ns1/func1" (get value "sym")))
-    (t/is (= 0 (get value "was-traced")))
+  (let [resp (trace-at-point "add-outer")]
+    (t/is (= "sayid.test-ns1/func1" (:value resp))
+          "the value stays the bare symbol, for older clients")
+    (t/is (= "sayid.test-ns1/func1" (:sym resp)))
+    (t/is (= 0 (:was-traced resp)))
     (t/is (contains? (:fn (:traced (sd/ws-get-active!)))
                      'sayid.test-ns1/func1)
           "the outer trace was applied")))
 
 (t/deftest trace-fn-at-point-reports-an-existing-trace
   (trace-at-point "add-outer")
-  (let [value (trace-at-point "add-inner")]
-    (t/is (= 1 (get value "was-traced")))
+  (let [resp (trace-at-point "add-inner")]
+    (t/is (= 1 (:was-traced resp)))
     (t/is (contains? (:inner-fn (:traced (sd/ws-get-active!)))
                      'sayid.test-ns1/func1)
           "the trace was switched to inner")))
 
-(t/deftest trace-fn-at-point-skips-managing-an-absent-trace
-  (let [value (trace-at-point "enable")]
-    (t/is (= 0 (get value "was-traced")))
+(t/deftest trace-fn-at-point-skips-enabling-an-absent-trace
+  (let [resp (trace-at-point "enable")]
+    (t/is (= 0 (:was-traced resp)))
     (t/is (empty? (:fn (:traced (sd/ws-get-active!))))
           "enable on an untraced fn applies nothing")))
 
+(t/deftest trace-fn-at-point-still-removes-an-out-of-sync-trace
+  ;; Remove must run even when the workspace doesn't list the fn as traced:
+  ;; it's the reconciliation path for a var whose trace fell out of sync.
+  (let [resp (trace-at-point "remove")]
+    (t/is (= 0 (:was-traced resp)))
+    (t/is (= "sayid.test-ns1/func1" (:sym resp))
+          "remove is applied (and reported) even for an untraced fn")))
+
 (t/deftest trace-fn-at-point-reports-nothing-at-point
-  (let [value (captured-value "sayid-trace-fn-at-point"
-                              {:action "add-outer" :file "fake.clj"
-                               :line 2 :column 2
-                               :source "(ns sayid.test-ns1)\n(nonexistent-fn-xyz 1)\n"})]
-    (t/is (empty? value) "no resolvable function replies with an empty map")))
+  (let [resp (captured-response "sayid-trace-fn-at-point"
+                                {:action "add-outer" :file "fake.clj"
+                                 :line 2 :column 2
+                                 :source "(ns sayid.test-ns1)\n(nonexistent-fn-xyz 1)\n"})]
+    (t/is (= "" (:value resp)) "no resolvable function replies with an empty value")
+    (t/is (nil? (:sym resp)))))
 
 (t/deftest show-traced-renders-the-audit
   (t/testing "sayid-show-traced returns a rendered [text properties] pair"

--- a/test/sayid/nrepl_middleware_test.clj
+++ b/test/sayid/nrepl_middleware_test.clj
@@ -260,6 +260,15 @@
       (t/is (str/includes? (get (first value) "name") "func1"))
       (t/is (bencode-roundtrips? value) "the data bencodes cleanly"))))
 
+(t/deftest log-count-reports-recorded-top-level-calls
+  (t/is (= 0 (captured-value "sayid-get-log-count" {}))
+        "an empty workspace has no recorded calls")
+  (sd/ws-add-trace-ns! ns1)
+  (ns1/func1 :a)
+  (ns1/func1 :b)
+  (t/is (= 2 (captured-value "sayid-get-log-count" {}))
+        "each top-level call adds a root"))
+
 ;;; --- Trace-at-point outcomes -------------------------------------------------
 
 (def ^:private point-source

--- a/test/sayid/nrepl_middleware_test.clj
+++ b/test/sayid/nrepl_middleware_test.clj
@@ -251,7 +251,14 @@
   (t/testing "sayid-query-data runs a query and returns data"
     (let [value (captured-value "sayid-query-data" {:query "()"})]
       (t/is (seq value))
-      (t/is (str/includes? (get (first value) "name") "func1")))))
+      (t/is (str/includes? (get (first value) "name") "func1"))))
+  (t/testing "sayid-query-form-at-point-data matches calls by source position"
+    (let [{:keys [file line]} (meta #'ns1/func1)
+          value (captured-value "sayid-query-form-at-point-data"
+                                {:file file :line line})]
+      (t/is (= 1 (count value)))
+      (t/is (str/includes? (get (first value) "name") "func1"))
+      (t/is (bencode-roundtrips? value) "the data bencodes cleanly"))))
 
 ;;; --- Trace-at-point outcomes -------------------------------------------------
 


### PR DESCRIPTION
A UX pass over the Emacs client, aimed at people new to Sayid. `C-c s` now opens a transient menu that groups the commands along the core loop (trace something, run your code, explore the recording) and shows live state about what's traced and recorded. Empty views explain how to get data instead of erroring, the trace commands describe their outcome in plain language, there's a plain `sayid-trace-fn` for people who haven't met the inner/outer distinction yet, and the workspace tree now covers everything the legacy text view could do (def/pprint/reproduction expressions, form queries), so it's where all default bindings land.

All the classic key sequences keep working - the menu uses the same keys, and `sayid-use-menu` set to nil restores the plain prefix map. The op changes are backward compatible with older middleware (details in doc/nrepl-api.md).